### PR TITLE
Fix ContinueAsNewInitiator enum

### DIFF
--- a/common/enum.proto
+++ b/common/enum.proto
@@ -60,7 +60,7 @@ enum IndexedValueType {
 }
 
 enum ContinueAsNewInitiator {
-    ContinueAsNewInitiatorDecider = 0;
-    ContinueAsNewInitiatorRetryPolicy = 1;
-    ContinueAsNewInitiatorCronSchedule = 2;
+   Decider = 0;
+   Retry = 1;
+   CronSchedule = 2;
 }


### PR DESCRIPTION
Missed one enum for the last PR. Also rename `RetryPolicy` value to `Retry` due to conflict.