### PR TITLE
Convert Control field to string

### DIFF
--- a/decision/message.proto
+++ b/decision/message.proto
@@ -76,7 +76,7 @@ message RequestCancelExternalWorkflowExecutionDecisionAttributes {
     string namespace = 1;
     string workflowId = 2;
     string runId = 3;
-    bytes control = 4;
+    string control = 4;
     bool childWorkflowOnly = 5;
 }
 
@@ -85,7 +85,7 @@ message SignalExternalWorkflowExecutionDecisionAttributes {
     execution.WorkflowExecution execution = 2;
     string signalName = 3;
     common.Payload input = 4;
-    bytes control = 5;
+    string control = 5;
     bool childWorkflowOnly = 6;
 }
 
@@ -126,7 +126,7 @@ message StartChildWorkflowExecutionDecisionAttributes {
     int32 executionStartToCloseTimeoutSeconds = 6;
     int32 taskStartToCloseTimeoutSeconds = 7;
     common.ParentClosePolicy parentClosePolicy = 8;
-    bytes control = 9;
+    string control = 9;
     common.WorkflowIdReusePolicy workflowIdReusePolicy = 10;
     common.RetryPolicy retryPolicy = 11;
     string cronSchedule = 12;

--- a/event/message.proto
+++ b/event/message.proto
@@ -108,11 +108,10 @@ message DecisionTaskStartedEventAttributes {
 }
 
 message DecisionTaskCompletedEventAttributes {
-    bytes executionContext = 1;
-    int64 scheduledEventId = 2;
-    int64 startedEventId = 3;
-    string identity = 4;
-    string binaryChecksum = 5;
+    int64 scheduledEventId = 1;
+    int64 startedEventId = 2;
+    string identity = 3;
+    string binaryChecksum = 4;
 }
 
 message DecisionTaskTimedOutEventAttributes {
@@ -264,7 +263,7 @@ message RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     int64 decisionTaskCompletedEventId = 1;
     string namespace = 2;
     execution.WorkflowExecution workflowExecution = 3;
-    bytes control = 4;
+    string control = 4;
     bool childWorkflowOnly = 5;
 }
 
@@ -274,7 +273,7 @@ message RequestCancelExternalWorkflowExecutionFailedEventAttributes {
     string namespace = 3;
     execution.WorkflowExecution workflowExecution = 4;
     int64 initiatedEventId = 5;
-    bytes control = 6;
+    string control = 6;
 }
 
 message ExternalWorkflowExecutionCancelRequestedEventAttributes {
@@ -289,7 +288,7 @@ message SignalExternalWorkflowExecutionInitiatedEventAttributes {
     execution.WorkflowExecution workflowExecution = 3;
     string signalName = 4;
     common.Payload input = 5;
-    bytes control = 6;
+    string control = 6;
     bool childWorkflowOnly = 7;
 }
 
@@ -299,14 +298,14 @@ message SignalExternalWorkflowExecutionFailedEventAttributes {
     string namespace = 3;
     execution.WorkflowExecution workflowExecution = 4;
     int64 initiatedEventId = 5;
-    bytes control = 6;
+    string control = 6;
 }
 
 message ExternalWorkflowExecutionSignaledEventAttributes {
     int64 initiatedEventId = 1;
     string namespace = 2;
     execution.WorkflowExecution workflowExecution = 3;
-    bytes control = 4;
+    string control = 4;
 }
 
 message UpsertWorkflowSearchAttributesEventAttributes {
@@ -323,7 +322,7 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     int32 executionStartToCloseTimeoutSeconds = 6;
     int32 taskStartToCloseTimeoutSeconds = 7;
     common.ParentClosePolicy parentClosePolicy = 8;
-    bytes control = 9;
+    string control = 9;
     int64 decisionTaskCompletedEventId = 10;
     common.WorkflowIdReusePolicy workflowIdReusePolicy = 11;
     common.RetryPolicy retryPolicy = 12;
@@ -338,7 +337,7 @@ message StartChildWorkflowExecutionFailedEventAttributes {
     string workflowId = 2;
     common.WorkflowType workflowType = 3;
     WorkflowExecutionFailedCause cause = 4;
-    bytes control = 5;
+    string control = 5;
     int64 initiatedEventId = 6;
     int64 decisionTaskCompletedEventId = 7;
 }

--- a/workflowservice/request_response.proto
+++ b/workflowservice/request_response.proto
@@ -178,13 +178,12 @@ message PollForDecisionTaskResponse {
 message RespondDecisionTaskCompletedRequest {
     bytes taskToken = 1;
     repeated decision.Decision decisions = 2;
-    bytes executionContext = 3;
-    string identity = 4;
-    decision.StickyExecutionAttributes stickyAttributes = 5;
-    bool returnNewDecisionTask = 6;
-    bool forceCreateNewDecisionTask = 7;
-    string binaryChecksum = 8;
-    map<string, query.WorkflowQueryResult> queryResults = 9;
+    string identity = 3;
+    decision.StickyExecutionAttributes stickyAttributes = 4;
+    bool returnNewDecisionTask = 5;
+    bool forceCreateNewDecisionTask = 6;
+    string binaryChecksum = 7;
+    map<string, query.WorkflowQueryResult> queryResults = 8;
 }
 
 message RespondDecisionTaskCompletedResponse {
@@ -333,7 +332,7 @@ message SignalWorkflowExecutionRequest {
     common.Payload input = 4;
     string identity = 5;
     string requestId = 6;
-    bytes control = 7;
+    string control = 7;
 }
 
 message SignalWorkflowExecutionResponse {
@@ -352,7 +351,7 @@ message SignalWithStartWorkflowExecutionRequest {
     common.WorkflowIdReusePolicy workflowIdReusePolicy = 10;
     string signalName = 11;
     common.Payload signalInput = 12;
-    bytes control = 13;
+    string control = 13;
     common.RetryPolicy retryPolicy = 14;
     string cronSchedule = 15;
     common.Memo memo = 16;


### PR DESCRIPTION
- `Control` field converted to strings everywhere according to https://github.com/temporalio/temporal/issues/107.
- `ExecutionContext` field is removed.