### PR TITLE
Add WorkflowExecutionState

### DIFF
--- a/execution/enum.proto
+++ b/execution/enum.proto
@@ -26,6 +26,15 @@ option go_package = "go.temporal.io/temporal-proto/execution";
 option java_package = "io.temporal.proto.execution";
 option java_multiple_files = true;
 
+enum WorkflowExecutionState {
+    WorkflowExecutionState_Created = 0;
+    WorkflowExecutionState_Running = 1;
+    WorkflowExecutionState_Completed = 2;
+    WorkflowExecutionState_Zombie = 3;
+    WorkflowExecutionState_Void = 4;
+    WorkflowExecutionState_Corrupted = 5;
+}
+
 enum WorkflowExecutionStatus {
     Unknown = 0;
     Running = 1;


### PR DESCRIPTION
This change is expected to feed into https://github.com/temporalio/temporal/pull/352, replacing the definition in [temporalio/proto/checksum/server_message.proto](https://github.com/temporalio/temporal/pull/352/files#diff-562b5aad555984585acd7e3b34add537R28)

The enum value names are prefixed with `WorkflowExecutionState` to avoid conflicts (and the resulting compilation errors) with the identically-named values in `WorkflowExecutionStatus`.