### PR TITLE
Request for activity cancellation should include scheduleId

### DIFF
--- a/decision/message.proto
+++ b/decision/message.proto
@@ -60,7 +60,8 @@ message ScheduleActivityTaskDecisionAttributes {
 }
 
 message RequestCancelActivityTaskDecisionAttributes {
-    string activityId = 1;
+    int64 scheduledEventId = 1;
+    string activityId = 2;
 }
 
 message StartTimerDecisionAttributes {

--- a/decision/message.proto
+++ b/decision/message.proto
@@ -60,8 +60,8 @@ message ScheduleActivityTaskDecisionAttributes {
 }
 
 message RequestCancelActivityTaskDecisionAttributes {
-    int64 scheduledEventId = 1;
-    string activityId = 2;
+    string activityId = 1;
+    int64 scheduledEventId = 2;
 }
 
 message StartTimerDecisionAttributes {

--- a/event/message.proto
+++ b/event/message.proto
@@ -205,9 +205,9 @@ message ActivityTaskTimedOutEventAttributes {
 }
 
 message ActivityTaskCancelRequestedEventAttributes {
-    int64 scheduledEventId = 1;
-    string activityId = 2;
-    int64 decisionTaskCompletedEventId = 3;
+    string activityId = 1;
+    int64 decisionTaskCompletedEventId = 2;
+    int64 scheduledEventId = 3;
 }
 
 message RequestCancelActivityTaskFailedEventAttributes {

--- a/event/message.proto
+++ b/event/message.proto
@@ -205,8 +205,9 @@ message ActivityTaskTimedOutEventAttributes {
 }
 
 message ActivityTaskCancelRequestedEventAttributes {
-    string activityId = 1;
-    int64 decisionTaskCompletedEventId = 2;
+    int64 scheduledEventId = 1;
+    string activityId = 2;
+    int64 decisionTaskCompletedEventId = 3;
 }
 
 message RequestCancelActivityTaskFailedEventAttributes {


### PR DESCRIPTION
Currently client passes activityId when requesting cancellation of
activity.  We instead want to include scheduleId as it makes
scanning for completed event simpler.
Once I consume this change on server will completely remove
activityId from decision for request cancel activity completion
and also remove request cancel activity failed event as we need to
instead fail the entire decision.