### PR TITLE
Add RetryStatus enum and use it

### DIFF
--- a/common/enum.proto
+++ b/common/enum.proto
@@ -74,7 +74,6 @@ enum TimeoutType {
 enum NoRetryReason{
     NotSet = 0;
     ErrorIsNonRetryable = 1;
-    RetryIsDisabled = 2;
-    Timeout = 3;
-    MaximumAttemptsExceeded = 4;
+    Timeout = 2;
+    MaximumAttemptsExceeded = 3;
 }

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -70,3 +70,11 @@ enum TimeoutType {
     ScheduleToClose = 2;
     Heartbeat = 3;
 }
+
+enum NoRetryReason{
+    NotSet = 0;
+    ErrorIsNonRetryable = 1;
+    RetryIsDisabled = 2;
+    Timeout = 3;
+    MaxAttemptsExceeded = 4;
+}

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -71,9 +71,12 @@ enum TimeoutType {
     Heartbeat = 3;
 }
 
-enum NoRetryReason{
-    NotSet = 0;
+enum RetryStatus{
+    Retrying = 0;
     ErrorIsNonRetryable = 1;
     Timeout = 2;
     MaximumAttemptsExceeded = 3;
+    RetryDisabled = 4;
+    InternalError = 5;
+    CancelRequested = 6;
 }

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -36,8 +36,8 @@ enum EncodingType {
 enum WorkflowIdReusePolicy {
     // Allow start a workflow execution using the same workflow Id, when workflow not running.
     AllowDuplicate = 0;
-     // Allow start a workflow execution using the same workflow Id, when workflow not running, and the last execution close state is in
-     // [terminated, cancelled, timed out, failed].
+    // Allow start a workflow execution using the same workflow Id, when workflow not running, and the last execution close state is in
+    // [terminated, cancelled, timed out, failed].
     AllowDuplicateFailedOnly = 1;
     // Do not allow start a workflow execution using the same workflow Id at all.
     RejectDuplicate = 2;
@@ -71,12 +71,12 @@ enum TimeoutType {
     Heartbeat = 3;
 }
 
-enum RetryStatus{
-    Retrying = 0;
+enum RetryStatus {
+    Retrying = 0; // or InProgress, or Active
     NonRetryableError = 1;
     Timeout = 2;
-    MaximumAttemptsExceeded = 3;
-    Disabled = 4;
-    InternalServerError = 5;
+    MaximumAttemptsExceeded = 3; // or MaximumAttemptsExhausted
+    Disabled = 4; // or RetryDisabled, or NotConfigured
+    InternalServerError = 5; // InternalError, ServiceError
     CancelRequested = 6;
 }

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -80,13 +80,3 @@ enum RetryStatus {
     InternalServerError = 5; // InternalError, ServiceError
     CancelRequested = 6;
 }
-
-enum RetryCompletionReason {
-    NotCompleted = 0; // or InProgress, or Active
-    NonRetryableFailure = 1;
-    Timeout = 2;
-    MaximumAttemptsExceeded = 3; // or MaximumAttemptsExhausted
-    RetryDisabled = 4; // or RetryDisabled, or NotConfigured
-    InternalServerError = 5; // InternalError, ServiceError
-    CancelRequested = 6;
-}

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -76,5 +76,5 @@ enum NoRetryReason{
     ErrorIsNonRetryable = 1;
     RetryIsDisabled = 2;
     Timeout = 3;
-    MaxAttemptsExceeded = 4;
+    MaximumAttemptsExceeded = 4;
 }

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -73,10 +73,20 @@ enum TimeoutType {
 
 enum RetryStatus {
     Retrying = 0; // or InProgress, or Active
-    NonRetryableError = 1;
+    NonRetryableFailure = 1;
     Timeout = 2;
     MaximumAttemptsExceeded = 3; // or MaximumAttemptsExhausted
     Disabled = 4; // or RetryDisabled, or NotConfigured
+    InternalServerError = 5; // InternalError, ServiceError
+    CancelRequested = 6;
+}
+
+enum RetryCompletionReason {
+    NotCompleted = 0; // or InProgress, or Active
+    NonRetryableFailure = 1;
+    Timeout = 2;
+    MaximumAttemptsExceeded = 3; // or MaximumAttemptsExhausted
+    RetryDisabled = 4; // or RetryDisabled, or NotConfigured
     InternalServerError = 5; // InternalError, ServiceError
     CancelRequested = 6;
 }

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -72,11 +72,11 @@ enum TimeoutType {
 }
 
 enum RetryStatus {
-    Retrying = 0; // or InProgress, or Active
+    InProgress = 0;
     NonRetryableFailure = 1;
     Timeout = 2;
-    MaximumAttemptsExceeded = 3; // or MaximumAttemptsExhausted
-    Disabled = 4; // or RetryDisabled, or NotConfigured
-    InternalServerError = 5; // InternalError, ServiceError
+    MaximumAttemptsReached = 3;
+    RetryPolicyNotSet = 4;
+    InternalServerError = 5;
     CancelRequested = 6;
 }

--- a/common/enum.proto
+++ b/common/enum.proto
@@ -73,10 +73,10 @@ enum TimeoutType {
 
 enum RetryStatus{
     Retrying = 0;
-    ErrorIsNonRetryable = 1;
+    NonRetryableError = 1;
     Timeout = 2;
     MaximumAttemptsExceeded = 3;
-    RetryDisabled = 4;
-    InternalError = 5;
+    Disabled = 4;
+    InternalServerError = 5;
     CancelRequested = 6;
 }

--- a/event/message.proto
+++ b/event/message.proto
@@ -191,13 +191,10 @@ message ActivityTaskFailedEventAttributes {
 }
 
 message ActivityTaskTimedOutEventAttributes {
-    common.Payloads lastHeartbeatDetails = 1;
     int64 scheduledEventId = 2;
     int64 startedEventId = 3;
-    common.TimeoutType timeoutType = 4;
-    // For retry activity, it may have a failure before timeout. It's important to keep those information for debug.
-    // Client can also provide the info for making next decision
-    failure.Failure lastFailure = 5;
+    // For retry activity, it may have a failure before timeout. It is stored as cause in timeoutFailure.
+    failure.Failure timeoutFailure = 5;
 }
 
 message ActivityTaskCancelRequestedEventAttributes {

--- a/event/message.proto
+++ b/event/message.proto
@@ -194,7 +194,7 @@ message ActivityTaskFailedEventAttributes {
 }
 
 message ActivityTaskTimedOutEventAttributes {
-    // For retry activity, it may have a failure before timeout. It is stored as cause in timeoutFailure.
+    // For retry activity, it may have a failure before timeout. It is stored as `cause` in `failure`.
     failure.Failure failure = 1;
     int64 scheduledEventId = 2;
     int64 startedEventId = 3;

--- a/event/message.proto
+++ b/event/message.proto
@@ -188,13 +188,15 @@ message ActivityTaskFailedEventAttributes {
     int64 scheduledEventId = 2;
     int64 startedEventId = 3;
     string identity = 4;
+    common.RetryStatus retryStatus = 5;
 }
 
 message ActivityTaskTimedOutEventAttributes {
+    // For retry activity, it may have a failure before timeout. It is stored as cause in timeoutFailure.
+    failure.Failure failure = 1;
     int64 scheduledEventId = 2;
     int64 startedEventId = 3;
-    // For retry activity, it may have a failure before timeout. It is stored as cause in timeoutFailure.
-    failure.Failure timeoutFailure = 5;
+    common.RetryStatus retryStatus = 4;
 }
 
 message ActivityTaskCancelRequestedEventAttributes {
@@ -377,6 +379,7 @@ message ChildWorkflowExecutionFailedEventAttributes {
     common.WorkflowType workflowType = 4;
     int64 initiatedEventId = 5;
     int64 startedEventId = 6;
+    common.RetryStatus retryStatus = 7;
 }
 
 message ChildWorkflowExecutionCanceledEventAttributes {
@@ -395,6 +398,7 @@ message ChildWorkflowExecutionTimedOutEventAttributes {
     common.WorkflowType workflowType = 4;
     int64 initiatedEventId = 5;
     int64 startedEventId = 6;
+    common.RetryStatus retryStatus = 7;
 }
 
 message ChildWorkflowExecutionTerminatedEventAttributes {

--- a/event/message.proto
+++ b/event/message.proto
@@ -77,11 +77,13 @@ message WorkflowExecutionCompletedEventAttributes {
 
 message WorkflowExecutionFailedEventAttributes {
     failure.Failure failure = 1;
-    int64 decisionTaskCompletedEventId = 2;
+    common.RetryStatus retryStatus = 2;
+    int64 decisionTaskCompletedEventId = 3;
 }
 
 message WorkflowExecutionTimedOutEventAttributes {
-    common.TimeoutType timeoutType = 1;
+    common.RetryStatus retryStatus = 1;
+    common.TimeoutType timeoutType = 2;
 }
 
 message WorkflowExecutionContinuedAsNewEventAttributes {

--- a/failure/message.proto
+++ b/failure/message.proto
@@ -61,9 +61,9 @@ message ResetWorkflowFailureInfo {
 message ActivityTaskFailureInfo {
     int64 scheduledEventId = 1;
     int64 startedEventId = 2;
-    common.ActivityType activityType = 3;
-    string activityId = 4;
-    string identity = 5;
+    string identity = 3;
+    common.ActivityType activityType = 4;
+    string activityId = 5;
     common.RetryStatus retryStatus = 6;
 }
 

--- a/failure/message.proto
+++ b/failure/message.proto
@@ -41,7 +41,6 @@ message ApplicationFailureInfo{
 message TimeoutFailureInfo{
     common.TimeoutType timeoutType = 1;
     common.Payloads lastHeartbeatDetails = 2;
-    failure.Failure lastFailure = 3;
 }
 
 message CanceledFailureInfo{
@@ -88,4 +87,5 @@ message Failure {
         ActivityTaskFailureInfo activityTaskFailureInfo = 11;
         ChildWorkflowExecutionFailureInfo childWorkflowExecutionFailureInfo = 12;
     }
+    common.NoRetryReason noRetryReason = 13;
 }

--- a/failure/message.proto
+++ b/failure/message.proto
@@ -87,5 +87,5 @@ message Failure {
         ActivityTaskFailureInfo activityTaskFailureInfo = 11;
         ChildWorkflowExecutionFailureInfo childWorkflowExecutionFailureInfo = 12;
     }
-    common.NoRetryReason noRetryReason = 13;
+    common.RetryStatus retryStatus = 13;
 }

--- a/failure/message.proto
+++ b/failure/message.proto
@@ -62,6 +62,7 @@ message ActivityTaskFailureInfo {
     int64 scheduledEventId = 1;
     int64 startedEventId = 2;
     string identity = 3;
+    common.RetryStatus retryStatus = 4;
 }
 
 message ChildWorkflowExecutionFailureInfo {
@@ -70,6 +71,7 @@ message ChildWorkflowExecutionFailureInfo {
     common.WorkflowType workflowType = 3;
     int64 initiatedEventId = 4;
     int64 startedEventId = 5;
+    common.RetryStatus retryStatus = 6;
 }
 
 message Failure {
@@ -87,5 +89,4 @@ message Failure {
         ActivityTaskFailureInfo activityTaskFailureInfo = 11;
         ChildWorkflowExecutionFailureInfo childWorkflowExecutionFailureInfo = 12;
     }
-    common.RetryStatus retryStatus = 13;
 }


### PR DESCRIPTION
Adding `RetryStatus` enum and field of this type to `Failure`. Generally, it indicates the reason why server stopped retrying (can be useful for debugging). There is also some extra logic on server based on this field.