### PR TITLE
Added fields to ActivityTaskFailureInfo and failure to the marker

### DIFF
--- a/decision/message.proto
+++ b/decision/message.proto
@@ -111,6 +111,7 @@ message RecordMarkerDecisionAttributes {
     string markerName = 1;
     common.Payloads details = 2;
     common.Header header = 3;
+    failure.Failure failure = 4;
 }
 
 message ContinueAsNewWorkflowExecutionDecisionAttributes {

--- a/event/message.proto
+++ b/event/message.proto
@@ -255,6 +255,7 @@ message MarkerRecordedEventAttributes {
     common.Payloads details = 2;
     int64 decisionTaskCompletedEventId = 3;
     common.Header header = 4;
+    failure.Failure failure = 5;
 }
 
 message WorkflowExecutionSignaledEventAttributes {

--- a/failure/message.proto
+++ b/failure/message.proto
@@ -32,30 +32,30 @@ option java_multiple_files = true;
 import "common/message.proto";
 import "common/enum.proto";
 
-message ApplicationFailureInfo{
+message ApplicationFailureInfo {
     string type = 1;
     bool nonRetryable = 2;
     common.Payloads details = 3;
 }
 
-message TimeoutFailureInfo{
+message TimeoutFailureInfo {
     common.TimeoutType timeoutType = 1;
     common.Payloads lastHeartbeatDetails = 2;
     failure.Failure lastFailure = 3;
 }
 
-message CanceledFailureInfo{
+message CanceledFailureInfo {
     common.Payloads details = 1;
 }
 
-message TerminatedFailureInfo{
+message TerminatedFailureInfo {
 }
 
-message ServerFailureInfo{
+message ServerFailureInfo {
     bool nonRetryable = 1;
 }
 
-message ResetWorkflowFailureInfo{
+message ResetWorkflowFailureInfo {
     common.Payloads lastHeartbeatDetails = 1;
 }
 
@@ -63,6 +63,8 @@ message ActivityTaskFailureInfo {
     int64 scheduledEventId = 1;
     int64 startedEventId = 2;
     string identity = 3;
+    common.ActivityType activityType = 4;
+    string activityId = 5;
 }
 
 message ChildWorkflowExecutionFailureInfo {


### PR DESCRIPTION
FailureInfo has to contain enough information to recreate the error without looking into the history.

Added failure to the marker decision and the corresponding event. It simplifies storing result of a local activity.