### PR TITLE
Remove workflow timeout type

### DIFF
--- a/event/enum.proto
+++ b/event/enum.proto
@@ -100,7 +100,16 @@ enum DecisionTaskFailedCause {
     BadSearchAttributes = 22;
 }
 
-enum WorkflowExecutionFailedCause {
-    ExternalWorkflowExecutionNotFound = 0;
-    WorkflowAlreadyExists = 1;
+enum StartChildWorkflowExecutionFailedCause {
+    WorkflowAlreadyExists = 0;
+}
+
+enum CancelExternalWorkflowExecutionFailedCause {
+    // TODO: Remove 1 suffix
+    ExternalWorkflowExecutionNotFound1 = 0;
+}
+
+enum SignalExternalWorkflowExecutionFailedCause {
+    // TODO: Remove 2 suffix
+    ExternalWorkflowExecutionNotFound2 = 0;
 }

--- a/event/enum.proto
+++ b/event/enum.proto
@@ -102,5 +102,5 @@ enum DecisionTaskFailedCause {
 
 enum WorkflowExecutionFailedCause {
     UnknownExternalWorkflowExecution = 0;
-    WorkflowAlreadyRunning = 1;
+    WorkflowAlreadyStarted = 1;
 }

--- a/event/enum.proto
+++ b/event/enum.proto
@@ -101,6 +101,6 @@ enum DecisionTaskFailedCause {
 }
 
 enum WorkflowExecutionFailedCause {
-    UnknownExternalWorkflowExecution = 0;
-    WorkflowAlreadyStarted = 1;
+    ExternalWorkflowExecutionNotFound = 0;
+    WorkflowAlreadyExists = 1;
 }

--- a/event/message.proto
+++ b/event/message.proto
@@ -279,7 +279,7 @@ message RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
 }
 
 message RequestCancelExternalWorkflowExecutionFailedEventAttributes {
-    WorkflowExecutionFailedCause cause = 1;
+    CancelExternalWorkflowExecutionFailedCause cause = 1;
     int64 decisionTaskCompletedEventId = 2;
     string namespace = 3;
     common.WorkflowExecution workflowExecution = 4;
@@ -304,7 +304,7 @@ message SignalExternalWorkflowExecutionInitiatedEventAttributes {
 }
 
 message SignalExternalWorkflowExecutionFailedEventAttributes {
-    WorkflowExecutionFailedCause cause = 1;
+    SignalExternalWorkflowExecutionFailedCause cause = 1;
     int64 decisionTaskCompletedEventId = 2;
     string namespace = 3;
     common.WorkflowExecution workflowExecution = 4;
@@ -351,7 +351,7 @@ message StartChildWorkflowExecutionFailedEventAttributes {
     string namespace = 1;
     string workflowId = 2;
     common.WorkflowType workflowType = 3;
-    WorkflowExecutionFailedCause cause = 4;
+    StartChildWorkflowExecutionFailedCause cause = 4;
     string control = 5;
     int64 initiatedEventId = 6;
     int64 decisionTaskCompletedEventId = 7;

--- a/event/message.proto
+++ b/event/message.proto
@@ -83,7 +83,6 @@ message WorkflowExecutionFailedEventAttributes {
 
 message WorkflowExecutionTimedOutEventAttributes {
     common.RetryStatus retryStatus = 1;
-    common.TimeoutType timeoutType = 2;
 }
 
 message WorkflowExecutionContinuedAsNewEventAttributes {
@@ -395,13 +394,12 @@ message ChildWorkflowExecutionCanceledEventAttributes {
 }
 
 message ChildWorkflowExecutionTimedOutEventAttributes {
-    common.TimeoutType timeoutType = 1;
-    string namespace = 2;
-    common.WorkflowExecution workflowExecution = 3;
-    common.WorkflowType workflowType = 4;
-    int64 initiatedEventId = 5;
-    int64 startedEventId = 6;
-    common.RetryStatus retryStatus = 7;
+    string namespace = 1;
+    common.WorkflowExecution workflowExecution = 2;
+    common.WorkflowType workflowType = 3;
+    int64 initiatedEventId = 4;
+    int64 startedEventId = 5;
+    common.RetryStatus retryStatus = 6;
 }
 
 message ChildWorkflowExecutionTerminatedEventAttributes {

--- a/execution/enum.proto
+++ b/execution/enum.proto
@@ -44,4 +44,3 @@ enum PendingActivityState {
     Started = 1;
     CancelRequested = 2;
 }
-

--- a/failure/message.proto
+++ b/failure/message.proto
@@ -58,7 +58,7 @@ message ResetWorkflowFailureInfo {
     common.Payloads lastHeartbeatDetails = 1;
 }
 
-message ActivityTaskFailureInfo {
+message ActivityFailureInfo {
     int64 scheduledEventId = 1;
     int64 startedEventId = 2;
     string identity = 3;
@@ -88,7 +88,7 @@ message Failure {
         TerminatedFailureInfo terminatedFailureInfo = 8;
         ServerFailureInfo serverFailureInfo = 9;
         ResetWorkflowFailureInfo resetWorkflowFailureInfo = 10;
-        ActivityTaskFailureInfo activityTaskFailureInfo = 11;
+        ActivityFailureInfo activityFailureInfo = 11;
         ChildWorkflowExecutionFailureInfo childWorkflowExecutionFailureInfo = 12;
     }
 }


### PR DESCRIPTION
1. Remove `WorkflowExecutionTimedOutEventAttributes.TimeoutType`.
2. Remove `ChildWorkflowExecutionTimedOutEventAttributes.TimeoutType`.
3. Split and rename `WorkflowExecutionFailedCause`enum values (closes #6, closes https://github.com/temporalio/temporal/issues/407).
4. Rename `ActivityTaskFailureInfo` to `ActivityFailureInfo`.