### PR TITLE
Fix google api-linter errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ gogo-grpc: clean $(PROTO_OUT)
 	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc --proto_path=$(PROTO_IMPORT) --gogoslick_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:$(PROTO_OUT) $(PROTO_DIR)*.proto;)
 
 fix-path:
-	mv -f $(PROTO_OUT)/temporal/* $(PROTO_OUT) && rm -d $(PROTO_OUT)/temporal
+	mv -f $(PROTO_OUT)/temporal/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
 
 # Plugins & tools
 

--- a/temporal/common/v1/message.proto
+++ b/temporal/common/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.common.v1;
 
 option go_package = "go.temporal.io/temporal-proto/common/v1;common";
-option java_package = "io.temporal.proto.common.v1";
+option java_package = "io.temporal.common.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/decision/v1/message.proto
+++ b/temporal/decision/v1/message.proto
@@ -43,22 +43,21 @@ message ScheduleActivityTaskDecisionAttributes {
     temporal.common.v1.Header header = 5;
     temporal.common.v1.Payloads input = 6;
     // Indicates how long the caller is willing to wait for an activity completion.
-    // Limits for how long retries are happening. Either this or startToCloseTimeoutSeconds is required.
+    // Limits for how long retries are happening. Either this or start_to_close_timeout_seconds must be specified.
     // When not specified defaults to the workflow execution timeout.
     int32 schedule_to_close_timeout_seconds = 7;
     // Limits time an activity task can stay in a task queue before a worker picks it up.
     // This timeout is always non retryable as all a retry would achieve is to put it back into the same queue.
-    // Defaults to scheduleToCloseTimeoutSeconds or workflow execution timeout if not specified.
+    // Defaults to schedule_to_close_timeout_seconds or workflow execution timeout if not specified.
     int32 schedule_to_start_timeout_seconds = 8;
     // Maximum time an activity is allowed to execute after a pick up by a worker.
-    // This timeout is always retryable. Either this or scheduleToCloseTimeoutSeconds is required.
+    // This timeout is always retryable. Either this or schedule_to_close_timeout_seconds must be specified.
     int32 start_to_close_timeout_seconds = 9;
     // Maximum time between successful worker heartbeats.
-    // Optional. By default no heartbeat is required.
     int32 heartbeat_timeout_seconds = 10;
-    // Activity retry policy. Note that activity is retried by default according to a default retry policy.
-    // To disable retries provide a retry policy with maximumAttempts equals to 1.
-    // The retries happen up to scheduleToCloseTimeout.
+    // Activities are provided by a default retry policy controlled through the service dynamic configuration.
+    // Retries are happening up to schedule_to_close_timeout.
+    // To disable retries set retry_policy.maximum_attempts to 1.
     temporal.common.v1.RetryPolicy retry_policy = 11;
 }
 

--- a/temporal/decision/v1/message.proto
+++ b/temporal/decision/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.decision.v1;
 
 option go_package = "go.temporal.io/temporal-proto/decision/v1;decision";
-option java_package = "io.temporal.proto.decision.v1";
+option java_package = "io.temporal.decision.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/enums/v1/common.proto
+++ b/temporal/enums/v1/common.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "CommonProto";
 

--- a/temporal/enums/v1/decision_type.proto
+++ b/temporal/enums/v1/decision_type.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "DecisionTypeProto";
 

--- a/temporal/enums/v1/event_type.proto
+++ b/temporal/enums/v1/event_type.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "EventTypeProto";
 

--- a/temporal/enums/v1/failed_cause.proto
+++ b/temporal/enums/v1/failed_cause.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "FailedCauseProto";
 

--- a/temporal/enums/v1/namespace.proto
+++ b/temporal/enums/v1/namespace.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "NamespaceProto";
 

--- a/temporal/enums/v1/query.proto
+++ b/temporal/enums/v1/query.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "QueryProto";
 

--- a/temporal/enums/v1/task_list.proto
+++ b/temporal/enums/v1/task_list.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "TaskListProto";
 

--- a/temporal/enums/v1/workflow.proto
+++ b/temporal/enums/v1/workflow.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.enums.v1;
 
 option go_package = "go.temporal.io/temporal-proto/enums/v1;enums";
-option java_package = "io.temporal.proto.enums.v1";
+option java_package = "io.temporal.enums.v1";
 option java_multiple_files = true;
 option java_outer_classname = "WorkflowProto";
 

--- a/temporal/errordetails/v1/message.proto
+++ b/temporal/errordetails/v1/message.proto
@@ -27,7 +27,7 @@ syntax = "proto3";
 package temporal.errordetails.v1;
 
 option go_package = "go.temporal.io/temporal-proto/errordetails/v1;errordetails";
-option java_package = "io.temporal.proto.errordetails.v1";
+option java_package = "io.temporal.errordetails.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/failure/v1/message.proto
+++ b/temporal/failure/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.failure.v1;
 
 option go_package = "go.temporal.io/temporal-proto/failure/v1;failure";
-option java_package = "io.temporal.proto.failure.v1";
+option java_package = "io.temporal.failure.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/filter/v1/message.proto
+++ b/temporal/filter/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.filter.v1;
 
 option go_package = "go.temporal.io/temporal-proto/filter/v1;filter";
-option java_package = "io.temporal.proto.filter.v1";
+option java_package = "io.temporal.filter.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/history/v1/message.proto
+++ b/temporal/history/v1/message.proto
@@ -153,20 +153,20 @@ message ActivityTaskScheduledEventAttributes {
     temporal.common.v1.Header header = 5;
     temporal.common.v1.Payloads input = 6;
     // Indicates how long the caller is willing to wait for an activity completion.
-    // Limits for how long retries are happening. Either this or startToCloseTimeoutSeconds is required.
+    // Limits for how long retries are happening. Either this or start_to_close_timeout_seconds must be specified.
     int32 schedule_to_close_timeout_seconds = 7;
     // Limits time an activity task can stay in a task queue before a worker picks it up.
     // This timeout is always non retryable as all a retry would achieve is to put it back into the same queue.
-    // Defaults to scheduleToCloseTimeoutSeconds or workflow execution timeout if not specified.
+    // Defaults to schedule_to_close_timeout_seconds or workflow execution timeout if not specified.
     int32 schedule_to_start_timeout_seconds = 8;
     // Maximum time an activity is allowed to execute after a pick up by a worker.
-    // This timeout is always retryable. Either this or scheduleToCloseTimeoutSeconds is required.
+    // This timeout is always retryable. Either this or schedule_to_close_timeout_seconds must be specified.
     int32 start_to_close_timeout_seconds = 9;
     // Maximum time between successful worker heartbeats.
     int32 heartbeat_timeout_seconds = 10;
     int64 decision_task_completed_event_id = 11;
     // Activities are provided by a default retry policy controlled through the service dynamic configuration.
-    // Retries are happening up to scheduleToCloseTimeout.
+    // Retries are happening up to schedule_to_close_timeout.
     // To disable retries set retryPolicy.maximumAttempts to 1.
     temporal.common.v1.RetryPolicy retry_policy = 12;
 }

--- a/temporal/history/v1/message.proto
+++ b/temporal/history/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.history.v1;
 
 option go_package = "go.temporal.io/temporal-proto/history/v1;history";
-option java_package = "io.temporal.proto.history.v1";
+option java_package = "io.temporal.history.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/history/v1/message.proto
+++ b/temporal/history/v1/message.proto
@@ -167,7 +167,7 @@ message ActivityTaskScheduledEventAttributes {
     int64 decision_task_completed_event_id = 11;
     // Activities are provided by a default retry policy controlled through the service dynamic configuration.
     // Retries are happening up to schedule_to_close_timeout.
-    // To disable retries set retryPolicy.maximumAttempts to 1.
+    // To disable retries set retry_policy.maximum_attempts to 1.
     temporal.common.v1.RetryPolicy retry_policy = 12;
 }
 

--- a/temporal/namespace/v1/message.proto
+++ b/temporal/namespace/v1/message.proto
@@ -42,7 +42,7 @@ message NamespaceInfo {
     string id = 6;
 }
 
-message NamespaceConfiguration {
+message NamespaceConfig {
     int32 workflow_execution_retention_period_in_days = 1;
     google.protobuf.BoolValue emit_metric = 2;
     BadBinaries bad_binaries = 3;
@@ -59,7 +59,7 @@ message BadBinaries {
 message BadBinaryInfo {
     string reason = 1;
     string operator = 2;
-    int64 created_time_nano = 3;
+    int64 create_time_nano = 3;
 }
 
 message UpdateNamespaceInfo {

--- a/temporal/namespace/v1/message.proto
+++ b/temporal/namespace/v1/message.proto
@@ -47,9 +47,9 @@ message NamespaceConfig {
     google.protobuf.BoolValue emit_metric = 2;
     BadBinaries bad_binaries = 3;
     temporal.enums.v1.ArchivalStatus history_archival_status = 4;
-    string history_archival_u_r_i = 5;
+    string history_archival_uri = 5;
     temporal.enums.v1.ArchivalStatus visibility_archival_status = 6;
-    string visibility_archival_u_r_i = 7;
+    string visibility_archival_uri = 7;
 }
 
 message BadBinaries {

--- a/temporal/namespace/v1/message.proto
+++ b/temporal/namespace/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.namespace.v1;
 
 option go_package = "go.temporal.io/temporal-proto/namespace/v1;namespace";
-option java_package = "io.temporal.proto.namespace.v1";
+option java_package = "io.temporal.namespace.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/query/v1/message.proto
+++ b/temporal/query/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.query.v1;
 
 option go_package = "go.temporal.io/temporal-proto/query/v1;query";
-option java_package = "io.temporal.proto.query.v1";
+option java_package = "io.temporal.query.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/replication/v1/message.proto
+++ b/temporal/replication/v1/message.proto
@@ -29,11 +29,11 @@ option java_package = "io.temporal.replication.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 
-message ClusterReplicationConfiguration {
+message ClusterReplicationConfig {
     string cluster_name = 1;
 }
 
-message NamespaceReplicationConfiguration {
+message NamespaceReplicationConfig {
     string active_cluster_name = 1;
-    repeated ClusterReplicationConfiguration clusters = 2;
+    repeated ClusterReplicationConfig clusters = 2;
 }

--- a/temporal/replication/v1/message.proto
+++ b/temporal/replication/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.replication.v1;
 
 option go_package = "go.temporal.io/temporal-proto/replication/v1;replication";
-option java_package = "io.temporal.proto.replication.v1";
+option java_package = "io.temporal.replication.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/tasklist/v1/message.proto
+++ b/temporal/tasklist/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.tasklist.v1;
 
 option go_package = "go.temporal.io/temporal-proto/tasklist/v1;tasklist";
-option java_package = "io.temporal.proto.tasklist.v1";
+option java_package = "io.temporal.tasklist.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/version/v1/message.proto
+++ b/temporal/version/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.version.v1;
 
 option go_package = "go.temporal.io/temporal-proto/version/v1;version";
-option java_package = "io.temporal.proto.version.v1";
+option java_package = "io.temporal.version.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/workflow/v1/message.proto
+++ b/temporal/workflow/v1/message.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.workflow.v1;
 
 option go_package = "go.temporal.io/temporal-proto/workflow/v1;workflow";
-option java_package = "io.temporal.proto.workflow.v1";
+option java_package = "io.temporal.workflow.v1";
 option java_multiple_files = true;
 option java_outer_classname = "MessageProto";
 

--- a/temporal/workflow/v1/message.proto
+++ b/temporal/workflow/v1/message.proto
@@ -76,7 +76,7 @@ message PendingActivityInfo {
 message PendingChildExecutionInfo {
     string workflow_id = 1;
     string run_id = 2;
-    string workflow_typ_name = 3;
+    string workflow_type_name = 3;
     int64 initiated_id = 4;
     temporal.enums.v1.ParentClosePolicy parent_close_policy = 5;
 }
@@ -89,9 +89,9 @@ message ResetPointInfo {
     string binary_checksum = 1;
     string run_id = 2;
     int64 first_decision_completed_id = 3;
-    int64 created_time_nano = 4;
+    int64 create_time_nano = 4;
     // The time that the run is deleted due to retention.
-    int64 expiring_time_nano = 5;
+    int64 expire_time_nano = 5;
     // false if the reset point has pending childWFs/reqCancels/signalExternals.
     bool resettable = 6;
 }

--- a/temporal/workflow/v1/message.proto
+++ b/temporal/workflow/v1/message.proto
@@ -51,7 +51,7 @@ message WorkflowExecutionInfo {
     string task_list = 13;
 }
 
-message WorkflowExecutionConfiguration {
+message WorkflowExecutionConfig {
     temporal.tasklist.v1.TaskList task_list = 1;
     int32 workflow_execution_timeout_seconds = 2;
     int32 workflow_run_timeout_seconds = 3;

--- a/temporal/workflowservice/v1/request_response.proto
+++ b/temporal/workflowservice/v1/request_response.proto
@@ -60,9 +60,9 @@ message RegisterNamespaceRequest {
     string security_token = 9;
     bool is_global_namespace = 10;
     temporal.enums.v1.ArchivalStatus history_archival_status = 11;
-    string history_archival_u_r_i = 12;
+    string history_archival_uri = 12;
     temporal.enums.v1.ArchivalStatus visibility_archival_status = 13;
-    string visibility_archival_u_r_i = 14;
+    string visibility_archival_uri = 14;
 }
 
 message RegisterNamespaceResponse {

--- a/temporal/workflowservice/v1/request_response.proto
+++ b/temporal/workflowservice/v1/request_response.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.workflowservice.v1;
 
 option go_package = "go.temporal.io/temporal-proto/workflowservice/v1;workflowservice";
-option java_package = "io.temporal.proto.workflowservice.v1";
+option java_package = "io.temporal.workflowservice.v1";
 option java_multiple_files = true;
 option java_outer_classname = "RequestResponseProto";
 

--- a/temporal/workflowservice/v1/request_response.proto
+++ b/temporal/workflowservice/v1/request_response.proto
@@ -93,7 +93,7 @@ message DescribeNamespaceResponse {
 
 message UpdateNamespaceRequest {
     string name = 1;
-    temporal.namespace.v1.UpdateNamespaceInfo updated_info = 2;
+    temporal.namespace.v1.UpdateNamespaceInfo update_info = 2;
     temporal.namespace.v1.NamespaceConfig config = 3;
     temporal.replication.v1.NamespaceReplicationConfig replication_config = 4;
     string security_token = 5;

--- a/temporal/workflowservice/v1/request_response.proto
+++ b/temporal/workflowservice/v1/request_response.proto
@@ -53,7 +53,7 @@ message RegisterNamespaceRequest {
     string owner_email = 3;
     int32 workflow_execution_retention_period_in_days = 4;
     bool emit_metric = 5;
-    repeated temporal.replication.v1.ClusterReplicationConfiguration clusters = 6;
+    repeated temporal.replication.v1.ClusterReplicationConfig clusters = 6;
     string active_cluster_name = 7;
     // A key-value map for any customized purpose.
     map<string, string> data = 8;
@@ -85,8 +85,8 @@ message DescribeNamespaceRequest {
 
 message DescribeNamespaceResponse {
     temporal.namespace.v1.NamespaceInfo namespace_info = 1;
-    temporal.namespace.v1.NamespaceConfiguration configuration = 2;
-    temporal.replication.v1.NamespaceReplicationConfiguration replication_configuration = 3;
+    temporal.namespace.v1.NamespaceConfig config = 2;
+    temporal.replication.v1.NamespaceReplicationConfig replication_config = 3;
     int64 failover_version = 4;
     bool is_global_namespace = 5;
 }
@@ -94,16 +94,16 @@ message DescribeNamespaceResponse {
 message UpdateNamespaceRequest {
     string name = 1;
     temporal.namespace.v1.UpdateNamespaceInfo updated_info = 2;
-    temporal.namespace.v1.NamespaceConfiguration configuration = 3;
-    temporal.replication.v1.NamespaceReplicationConfiguration replication_configuration = 4;
+    temporal.namespace.v1.NamespaceConfig config = 3;
+    temporal.replication.v1.NamespaceReplicationConfig replication_config = 4;
     string security_token = 5;
     string delete_bad_binary = 6;
 }
 
 message UpdateNamespaceResponse {
     temporal.namespace.v1.NamespaceInfo namespace_info = 1;
-    temporal.namespace.v1.NamespaceConfiguration configuration = 2;
-    temporal.replication.v1.NamespaceReplicationConfiguration replication_configuration = 3;
+    temporal.namespace.v1.NamespaceConfig config = 2;
+    temporal.replication.v1.NamespaceReplicationConfig replication_config = 3;
     int64 failover_version = 4;
     bool is_global_namespace = 5;
 }
@@ -526,7 +526,7 @@ message DescribeWorkflowExecutionRequest {
 }
 
 message DescribeWorkflowExecutionResponse {
-    temporal.workflow.v1.WorkflowExecutionConfiguration execution_configuration = 1;
+    temporal.workflow.v1.WorkflowExecutionConfig execution_config = 1;
     temporal.workflow.v1.WorkflowExecutionInfo workflow_execution_info = 2;
     repeated temporal.workflow.v1.PendingActivityInfo pending_activities = 3;
     repeated temporal.workflow.v1.PendingChildExecutionInfo pending_children = 4;

--- a/temporal/workflowservice/v1/service.proto
+++ b/temporal/workflowservice/v1/service.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 package temporal.workflowservice.v1;
 
 option go_package = "go.temporal.io/temporal-proto/workflowservice/v1;workflowservice";
-option java_package = "io.temporal.proto.workflowservice.v1";
+option java_package = "io.temporal.workflowservice.v1";
 option java_multiple_files = true;
 option java_outer_classname = "ServiceProto";
 


### PR DESCRIPTION
This is step 1 of google api-linter errors fixes. These are obvious and easy to fix.
1. `java_package = "io.temporal.proto.common.v1";` => `java_package = "io.temporal.common.v1";` (it needs to match proto package name and I don't want to add `proto` to proto package name).
2. `Configuration` => `Config`
3. `created_time` => `create_time` (and other with `ed` suffix)
4. Few typos

Let's discuss all others later.