### PR TITLE
Bad build ids api changes

### DIFF
--- a/temporal/api/batch/v1/message.proto
+++ b/temporal/api/batch/v1/message.proto
@@ -93,9 +93,13 @@ message BatchOperationDeletion {
 // Keep the parameter in sync with temporal.api.workflowservice.v1.ResetWorkflowExecutionRequest.
 message BatchOperationReset {
   // Reset type.
-  temporal.api.enums.v1.ResetType reset_type = 1; 
+  temporal.api.enums.v1.ResetType reset_type = 1;
   // History event reapply options.
-  temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 2; 
+  temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 2;
   // The identity of the worker/client.
   string identity = 3;
+
+  // For reset_type == RESET_TYPE_BUILD_ID only:
+  // Resets to before the first workflow task processed by the specified build id.
+  string reset_build_id = 4;
 }

--- a/temporal/api/batch/v1/message.proto
+++ b/temporal/api/batch/v1/message.proto
@@ -100,6 +100,5 @@ message BatchOperationReset {
   string identity = 3;
 
   // For reset_type == RESET_TYPE_BUILD_ID only:
-  // Resets to before the first workflow task processed by the specified build id.
-  string reset_build_id = 4;
+  temporal.api.common.v1.BuildIdResetOptions reset_build_id = 4;
 }

--- a/temporal/api/batch/v1/message.proto
+++ b/temporal/api/batch/v1/message.proto
@@ -92,13 +92,16 @@ message BatchOperationDeletion {
 // BatchOperationReset sends reset requests to batch workflows.
 // Keep the parameter in sync with temporal.api.workflowservice.v1.ResetWorkflowExecutionRequest.
 message BatchOperationReset {
+  // The identity of the worker/client.
+  string identity = 3;
+
+  // New API (exclusive with `reset_type` and `reset_reapply_type`):
+  temporal.api.common.v1.ResetOptions options = 4;
+
+  // Old API (exclusive with `options`):
   // Reset type.
   temporal.api.enums.v1.ResetType reset_type = 1;
   // History event reapply options.
   temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 2;
-  // The identity of the worker/client.
-  string identity = 3;
 
-  // For reset_type == RESET_TYPE_BUILD_ID only:
-  temporal.api.common.v1.BuildIdResetOptions reset_build_id = 4;
 }

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -149,3 +149,12 @@ message WorkerVersionCapabilities {
 
     // Later, may include info like "I can process WASM and/or JS bundles"
 }
+
+// Common options for performing a workflow reset based on build id.
+message BuildIdResetOptions {
+    // Resets to before the first workflow task processed by this build id. Note that by default,
+    // this reset is allowed to be to a prior run in a chain of continue-as-new.
+    string build_id = 1;
+    // If true, limit the reset to only within the current run.
+    bool current_run_only = 2;
+}

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -32,10 +32,12 @@ option ruby_package = "Temporalio::Api::Common::V1";
 option csharp_namespace = "Temporalio.Api.Common.V1";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
 
 import "dependencies/gogoproto/gogo.proto";
 
 import "temporal/api/enums/v1/common.proto";
+import "temporal/api/enums/v1/reset.proto";
 
 message DataBlob {
     temporal.api.enums.v1.EncodingType encoding_type = 1;
@@ -150,11 +152,28 @@ message WorkerVersionCapabilities {
     // Later, may include info like "I can process WASM and/or JS bundles"
 }
 
-// Common options for performing a workflow reset based on build id.
-message BuildIdResetOptions {
-    // Resets to before the first workflow task processed by this build id. Note that by default,
-    // this reset is allowed to be to a prior run in a chain of continue-as-new.
-    string build_id = 1;
-    // If true, limit the reset to only within the current run.
-    bool current_run_only = 2;
+message ResetOptions {
+    // Which workflow task to reset to.
+    oneof target {
+        // Resets to event of the first workflow task completed, or if it does not exist, the event after task scheduled.
+        google.protobuf.Empty first_workflow_task = 1;
+        // Resets to event of the last workflow task completed, or if it does not exist, the event after task scheduled.
+        google.protobuf.Empty last_workflow_task = 2;
+        // The id of a specific `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
+        // `WORKFLOW_TASK_STARTED` event to reset to.
+        int64 workflow_task_id = 3;
+        // Resets to before the first workflow task processed by this build id.
+        // If the workflow was not processed by the build id, or the workflow task can't be
+        // determined, no reset will be performed.
+        // Note that by default, this reset is allowed to be to a prior run in a chain of
+        // continue-as-new.
+        string build_id = 4;
+    }
+
+    // History event reapply options.
+    temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 10;
+
+    // If true, limit the reset to only within the current run. (Applies to build_id targets and
+    // possibly others in the future.)
+    bool current_run_only = 11;
 }

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -31,7 +31,7 @@ option java_outer_classname = "ResetProto";
 option ruby_package = "Temporalio::Api::Enums::V1";
 option csharp_namespace = "Temporalio.Api.Enums.V1";
 
-// Reset reapplay(replay) options
+// Reset reapply (replay) options
 // * RESET_REAPPLY_TYPE_SIGNAL (default) - Signals are reapplied when workflow is reset
 // * RESET_REAPPLY_TYPE_NONE - nothing is reapplied
 enum ResetReapplyType {
@@ -41,10 +41,14 @@ enum ResetReapplyType {
 }
 
 // Reset type options
-enum ResetType { 
+enum ResetType {
     RESET_TYPE_UNSPECIFIED = 0;
     // Resets to event of the first workflow task completed, or if it does not exist, the event after task scheduled.
     RESET_TYPE_FIRST_WORKFLOW_TASK = 1;
     // Resets to event of the last workflow task completed, or if it does not exist, the event after task scheduled.
     RESET_TYPE_LAST_WORKFLOW_TASK = 2;
+    // Resets to before the first workflow task processed by the specified build id.
+    // If the workflow was not processed by the build id, or the workflow task can't be
+    // determined, no reset will be performed.
+    RESET_TYPE_BUILD_ID = 3;
 }

--- a/temporal/api/enums/v1/reset.proto
+++ b/temporal/api/enums/v1/reset.proto
@@ -40,15 +40,11 @@ enum ResetReapplyType {
     RESET_REAPPLY_TYPE_NONE = 2;
 }
 
-// Reset type options
+// Reset type options. Deprecated, see temporal.api.common.v1.ResetOptions.
 enum ResetType {
     RESET_TYPE_UNSPECIFIED = 0;
     // Resets to event of the first workflow task completed, or if it does not exist, the event after task scheduled.
     RESET_TYPE_FIRST_WORKFLOW_TASK = 1;
     // Resets to event of the last workflow task completed, or if it does not exist, the event after task scheduled.
     RESET_TYPE_LAST_WORKFLOW_TASK = 2;
-    // Resets to before the first workflow task processed by the specified build id.
-    // If the workflow was not processed by the build id, or the workflow task can't be
-    // determined, no reset will be performed.
-    RESET_TYPE_BUILD_ID = 3;
 }

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -110,4 +110,6 @@ message WorkflowNotReadyFailure {
 message NewerBuildExistsFailure {
     // The current default compatible build ID which will receive tasks
     string default_build_id = 1;
+    // If this failure is due to the polling build id being marked as a bad build.
+    bool is_bad_build = 2;
 }

--- a/temporal/api/taskqueue/v1/message.proto
+++ b/temporal/api/taskqueue/v1/message.proto
@@ -95,6 +95,10 @@ message StickyExecutionAttributes {
 message CompatibleVersionSet {
     // All the compatible versions, unordered, except for the last element, which is considered the set "default".
     repeated string build_ids = 1;
+    // Build ids that have been marked as bad. If the last element in build_ids is also in
+    // bad_build_ids, then no tasks will be dispatched on this version set until the default is
+    // changed.
+    repeated string bad_build_ids = 2;
 }
 
 // Reachability of tasks for a worker on a single task queue.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -108,9 +108,13 @@ message ResetPoints {
     repeated ResetPointInfo points = 1;
 }
 
+// ResetPointInfo records the workflow event id that is the first one processed by a given
+// build id or binary checksum. A new reset point will be created if either build id or binary
+// checksum changes (although in general only one or the other will be used at a time).
 message ResetPointInfo {
-    // A worker binary version identifier, will be deprecated and superseded by a newer concept of
-    // build_id.
+    // Worker build id.
+    string build_id = 7;
+    // A worker binary version identifier (deprecated).
     string binary_checksum = 1;
     // The first run ID in the execution chain that was touched by this worker build.
     string run_id = 2;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -663,15 +663,16 @@ message ResetWorkflowExecutionRequest {
     string namespace = 1;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
     string reason = 3;
-    oneof reset_type {
-        // The id of a `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
-        // `WORKFLOW_TASK_STARTED` event to reset to.
-        int64 workflow_task_finish_event_id = 4;
-        // Reset to before a specific build id.
-        temporal.api.common.v1.BuildIdResetOptions reset_build_id = 7;
-    }
     // Used to de-dupe reset requests
     string request_id = 5;
+
+    // New API (exclusive with `workflow_task_finish_event_id` and `reset_reapply_type`):
+    temporal.api.common.v1.ResetOptions options = 7;
+
+    // Old API (exclusive with `options`):
+    // The id of a `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
+    // `WORKFLOW_TASK_STARTED` event to reset to.
+    int64 workflow_task_finish_event_id = 4;
     // Reset reapply (replay) options.
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -667,7 +667,8 @@ message ResetWorkflowExecutionRequest {
         // The id of a `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
         // `WORKFLOW_TASK_STARTED` event to reset to.
         int64 workflow_task_finish_event_id = 4;
-        string reset_build_id = 7;
+        // Reset to before a specific build id.
+        temporal.api.common.v1.BuildIdResetOptions reset_build_id = 7;
     }
     // Used to de-dupe reset requests
     string request_id = 5;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1110,6 +1110,16 @@ message UpdateWorkerBuildIdCompatibilityRequest {
         string secondary_set_build_id = 2;
     }
 
+    message MarkBadBuild {
+        // The build id to mark as bad.
+        string bad_build_id = 1;
+        // If promote_build_id is set, then also promote it to be the default of the set.
+        // If it's not set, then no tasks will be dispatched on the task queue set until another
+        // build id is made the default by another call to UpdateWorkerBuildIdCompatibility that
+        // sets/adds a new default for the set.
+        string promote_build_id = 2;
+    }
+
     string namespace = 1;
     // Must be set, the task queue to apply changes to. Because all workers on a given task queue
     // must have the same set of workflow & activity implementations, there is no reason to specify
@@ -1142,6 +1152,17 @@ message UpdateWorkerBuildIdCompatibilityRequest {
         // declare as compatible. The unusual case of incomplete replication during failover could
         // also result in a split set, which this operation can repair.
         MergeSets merge_sets = 7;
+        // Mark a build as "bad" for a particular task queue. This means that:
+        // 1. the build will not receive any more tasks (workflow or activity)
+        // 2. it may not be promoted to the set default anymore
+        // See the MarkBadBuild for more information.
+        // Note that this only applies to a particular task queue. To mark a build as bad on
+        // multiple task queues, use GetWorkerTaskReachability to find the task queues that a build
+        // id has been registered with and make a separate call for each one.
+        // Also note that this only affects new task dispatch. To also reset workflows with tasks
+        // that were processed by this build, use StartBatchOperation with a query that includes
+        // BuildIds and reset_type RESET_TYPE_BUILD_ID.
+        MarkBadBuild mark_bad_build = 8;
     }
 }
 message UpdateWorkerBuildIdCompatibilityResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -663,16 +663,11 @@ message ResetWorkflowExecutionRequest {
     string namespace = 1;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
     string reason = 3;
-    // Used to de-dupe reset requests
-    string request_id = 5;
-
-    // New API (exclusive with `workflow_task_finish_event_id` and `reset_reapply_type`):
-    temporal.api.common.v1.ResetOptions options = 7;
-
-    // Old API (exclusive with `options`):
     // The id of a `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
     // `WORKFLOW_TASK_STARTED` event to reset to.
     int64 workflow_task_finish_event_id = 4;
+    // Used to de-dupe reset requests
+    string request_id = 5;
     // Reset reapply (replay) options.
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1126,9 +1126,15 @@ message UpdateWorkerBuildIdCompatibilityRequest {
     }
 
     string namespace = 1;
-    // Must be set, the task queue to apply changes to. Because all workers on a given task queue
-    // must have the same set of workflow & activity implementations, there is no reason to specify
-    // a task queue type here.
+    // The task queue to apply changes to. Must be set for most operations.
+    //
+    // Because all workers on a given task queue must have the same set of workflow & activity
+    // implementations, there is no reason to specify a task queue type here.
+    //
+    // When operation is mark_bad_build, task_queue may be left empty and the operation will be
+    // applied to all task queues that have that build id registered. Note that in this case, and if
+    // an error is returned, the operation may have been partially applied to some task queues and
+    // not others.
     string task_queue = 2;
     oneof operation {
         // A new build id. This operation will create a new set which will be the new overall
@@ -1161,12 +1167,9 @@ message UpdateWorkerBuildIdCompatibilityRequest {
         // 1. the build will not receive any more tasks (workflow or activity)
         // 2. it may not be promoted to the set default anymore
         // See the MarkBadBuild for more information.
-        // Note that this only applies to a particular task queue. To mark a build as bad on
-        // multiple task queues, use GetWorkerTaskReachability to find the task queues that a build
-        // id has been registered with and make a separate call for each one.
-        // Also note that this only affects new task dispatch. To also reset workflows with tasks
+        // Note that this only affects new task dispatch. To also reset workflows with tasks
         // that were processed by this build, use StartBatchOperation with a query that includes
-        // BuildIds and reset_type RESET_TYPE_BUILD_ID.
+        // BuildIds and use a build_id target in ResetOptions.
         MarkBadBuild mark_bad_build = 8;
     }
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -663,12 +663,15 @@ message ResetWorkflowExecutionRequest {
     string namespace = 1;
     temporal.api.common.v1.WorkflowExecution workflow_execution = 2;
     string reason = 3;
-    // The id of a `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
-    // `WORKFLOW_TASK_STARTED` event to reset to.
-    int64 workflow_task_finish_event_id = 4;
+    oneof reset_type {
+        // The id of a `WORKFLOW_TASK_COMPLETED`,`WORKFLOW_TASK_TIMED_OUT`, `WORKFLOW_TASK_FAILED`, or
+        // `WORKFLOW_TASK_STARTED` event to reset to.
+        int64 workflow_task_finish_event_id = 4;
+        string reset_build_id = 7;
+    }
     // Used to de-dupe reset requests
     string request_id = 5;
-    // Reset reapplay(replay) options.
+    // Reset reapply (replay) options.
     temporal.api.enums.v1.ResetReapplyType reset_reapply_type = 6;
 }
 


### PR DESCRIPTION
**What changed?**
- Add `MarkBadBuild` option to `UpdateWorkerBuildIdCompatibilityRequest` and related messages
- Add build-id-based option to reset, including `RESET_TYPE_BUILD_ID` to `ResetType` in `BatchOperationReset`

**Why?**
Help recover from a bad deployment situation

**Breaking changes**
no
