### PR TITLE
Keep VersionSummary and VersionLocalState in sync

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -6968,7 +6968,27 @@
           "format": "date-time"
         },
         "drainageStatus": {
-          "$ref": "#/definitions/v1VersionDrainageStatus"
+          "$ref": "#/definitions/v1VersionDrainageStatus",
+          "description": "Deprecated. Use `drainage_info` instead."
+        },
+        "drainageInfo": {
+          "$ref": "#/definitions/v1VersionDrainageInfo",
+          "title": "Information about workflow drainage to help the user determine when it is safe\nto decommission a Version. Not present while version is current or ramping"
+        },
+        "currentSinceTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Nil if not current."
+        },
+        "rampingSinceTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Nil if not ramping. Updated when the version first starts ramping, not on each ramp change."
+        },
+        "routingUpdateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time `current_since_time`, `ramping_since_time, or `ramp_percentage` of this version changed."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11947,7 +11947,32 @@ components:
             - VERSION_DRAINAGE_STATUS_DRAINING
             - VERSION_DRAINAGE_STATUS_DRAINED
           type: string
+          description: Deprecated. Use `drainage_info` instead.
           format: enum
+        drainageInfo:
+          allOf:
+            - $ref: '#/components/schemas/VersionDrainageInfo'
+          description: |-
+            Information about workflow drainage to help the user determine when it is safe
+             to decommission a Version. Not present while version is current or ramping
+        currentSinceTime:
+          type: string
+          description: |-
+            Nil if not current.
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: 'Since' captures the field semantics despite being a preposition. --)
+          format: date-time
+        rampingSinceTime:
+          type: string
+          description: |-
+            Nil if not ramping. Updated when the version first starts ramping, not on each ramp change.
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: 'Since' captures the field semantics despite being a preposition. --)
+          format: date-time
+        routingUpdateTime:
+          type: string
+          description: Last time `current_since_time`, `ramping_since_time, or `ramp_percentage` of this version changed.
+          format: date-time
     WorkerDeploymentOptions:
       type: object
       properties:

--- a/temporal/api/deployment/v1/message.proto
+++ b/temporal/api/deployment/v1/message.proto
@@ -210,7 +210,21 @@ message WorkerDeploymentInfo {
         // The fully-qualified string representation of the version, in the form "<deployment_name>.<build_id>".
         string version = 1;
         google.protobuf.Timestamp create_time = 2;
+        // Deprecated. Use `drainage_info` instead.
         enums.v1.VersionDrainageStatus drainage_status = 3;
+        // Information about workflow drainage to help the user determine when it is safe
+        // to decommission a Version. Not present while version is current or ramping
+        VersionDrainageInfo drainage_info = 4;
+        // Nil if not current.
+        // (-- api-linter: core::0140::prepositions=disabled
+        //     aip.dev/not-precedent: 'Since' captures the field semantics despite being a preposition. --)
+        google.protobuf.Timestamp current_since_time = 5;
+        // Nil if not ramping. Updated when the version first starts ramping, not on each ramp change.
+        // (-- api-linter: core::0140::prepositions=disabled
+        //     aip.dev/not-precedent: 'Since' captures the field semantics despite being a preposition. --)
+        google.protobuf.Timestamp ramping_since_time = 6;
+        // Last time `current_since_time`, `ramping_since_time, or `ramp_percentage` of this version changed.
+        google.protobuf.Timestamp routing_update_time = 7;
     }
 }
 


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
- Added missing fields from `VersionLocalState` that were not present in `VersionSummary`.


<!-- Tell your future self why have you made these changes -->
**Why?**
- Seems like the UI is querying a bunch of different places to get information about a specific version. This might be annoying and the aim of this PR is to make `VersionSummary` the place to go for information related to a specific version.
- This shall also reduce the number of API calls to get information about a version.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
- https://github.com/temporalio/temporal/pull/7682
