### PR TITLE
add create_request_id to child initiated event

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13835,6 +13835,10 @@
         "priority": {
           "$ref": "#/definitions/v1Priority",
           "title": "Priority metadata"
+        },
+        "createRequestId": {
+          "type": "string",
+          "description": "A unique identifier for the request to start this child workflow execution. This is used to\ndeduplicate requests to start a child workflow execution with the same workflow ID."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11086,6 +11086,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/Priority'
           description: Priority metadata
+        createRequestId:
+          type: string
+          description: |-
+            A unique identifier for the request to start this child workflow execution. This is used to
+             deduplicate requests to start a child workflow execution with the same workflow ID.
     StartWorkflowExecutionRequest:
       type: object
       properties:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -665,6 +665,9 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     bool inherit_build_id = 19;
     // Priority metadata
     temporal.api.common.v1.Priority priority = 20;
+    // A unique identifier for the request to start this child workflow execution. This is used to
+    // deduplicate requests to start a child workflow execution with the same workflow ID.
+    string create_request_id = 21;
 }
 
 message StartChildWorkflowExecutionFailedEventAttributes {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
Add request_id to child initiated event.


<!-- Tell your future self why have you made these changes -->
**Why**
For event-based replication, if request_id is not replicated to standby clusters, after failover, standby cannot dedup the start workflow request.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/7813