### PR TITLE
add `WorkflowTaskFailedCause` to `RespondQueryTaskCompletedRequest`

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -985,6 +985,9 @@ message RespondQueryTaskCompletedRequest {
     // traces.
     // Mutually exclusive with `query_result`. Set when the query fails.
     temporal.api.failure.v1.Failure failure = 7;
+    // Why did the task fail? It's important to note that many of the variants in this enum cannot
+    // apply to worker responses. See the type's doc for more.
+    temporal.api.enums.v1.WorkflowTaskFailedCause cause = 8;
 }
 
 message RespondQueryTaskCompletedResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Adding a `cause` field to `RespondQueryTaskCompletedRequest` similar to `RespondWorkflowTaskFailedRequest`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Server needs a clean way to distinguish NDE and some other versioning-related errors for the dry-run API and user-experience insights.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
None at the moment.- SDK needs to send the info
