### PR TITLE
Proto changes to support activity pause by type options

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7054,27 +7054,6 @@
         }
       }
     },
-    "PauseActivityRequestPauseByType": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "option": {
-          "$ref": "#/definitions/PauseActivityRequestPauseByTypeOption"
-        }
-      }
-    },
-    "PauseActivityRequestPauseByTypeOption": {
-      "type": "string",
-      "enum": [
-        "PAUSE_BY_TYPE_OPTION_UNSPECIFIED",
-        "PAUSE_BY_TYPE_OPTION_ALL",
-        "PAUSE_BY_TYPE_OPTION_RUNNING",
-        "PAUSE_BY_TYPE_OPTION_FUTURE"
-      ],
-      "default": "PAUSE_BY_TYPE_OPTION_UNSPECIFIED"
-    },
     "PauseInfoManual": {
       "type": "object",
       "properties": {
@@ -7534,9 +7513,9 @@
           "type": "string",
           "description": "Only the activity with this ID will be paused."
         },
-        "pauseByType": {
-          "$ref": "#/definitions/PauseActivityRequestPauseByType",
-          "description": "Pause by type with option to pause all, running, or future activities of this type."
+        "type": {
+          "type": "string",
+          "description": "Pause all running activities of this type."
         },
         "reason": {
           "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7515,11 +7515,19 @@
         },
         "type": {
           "type": "string",
-          "description": "Pause all running activities of this type."
+          "description": "Pause activities of this type."
+        },
+        "pauseAll": {
+          "type": "boolean",
+          "description": "Pause all activities."
         },
         "reason": {
           "type": "string",
           "description": "Reason to pause the activity."
+        },
+        "activityState": {
+          "$ref": "#/definitions/v1PauseOptionActivityState",
+          "description": "which activities to pause - current, future or both."
         }
       }
     },
@@ -8381,11 +8389,11 @@
         },
         "type": {
           "type": "string",
-          "description": "Unpause all running activities with of this type."
+          "description": "Unpause activities of this type."
         },
         "unpauseAll": {
           "type": "boolean",
-          "description": "Unpause all running activities."
+          "description": "Unpause all activities."
         },
         "resetAttempts": {
           "type": "boolean",
@@ -8398,6 +8406,10 @@
         "jitter": {
           "type": "string",
           "description": "If set, the activity will start at a random time within the specified jitter duration."
+        },
+        "activityState": {
+          "$ref": "#/definitions/v1PauseOptionActivityState",
+          "description": "which activities to unpause - current, future or both."
         }
       }
     },
@@ -12104,6 +12116,17 @@
     },
     "v1PauseActivityResponse": {
       "type": "object"
+    },
+    "v1PauseOptionActivityState": {
+      "type": "string",
+      "enum": [
+        "PAUSE_OPTION_ACTIVITY_STATE_UNSPECIFIED",
+        "PAUSE_OPTION_ACTIVITY_STATE_RUNNING",
+        "PAUSE_OPTION_ACTIVITY_STATE_FUTURE",
+        "PAUSE_OPTION_ACTIVITY_STATE_BOTH"
+      ],
+      "default": "PAUSE_OPTION_ACTIVITY_STATE_UNSPECIFIED",
+      "description": "Pause option activity state is used to specify if we want to pause/unpause just the current activity, or just the future activities or both."
     },
     "v1Payload": {
       "description": "Arbitrary payload data in an unconstrained format.\nThis may be activity input parameters, a workflow result, a memo, etc.\n"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -7054,6 +7054,27 @@
         }
       }
     },
+    "PauseActivityRequestPauseByType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "option": {
+          "$ref": "#/definitions/PauseActivityRequestPauseByTypeOption"
+        }
+      }
+    },
+    "PauseActivityRequestPauseByTypeOption": {
+      "type": "string",
+      "enum": [
+        "PAUSE_BY_TYPE_OPTION_UNSPECIFIED",
+        "PAUSE_BY_TYPE_OPTION_ALL",
+        "PAUSE_BY_TYPE_OPTION_RUNNING",
+        "PAUSE_BY_TYPE_OPTION_FUTURE"
+      ],
+      "default": "PAUSE_BY_TYPE_OPTION_UNSPECIFIED"
+    },
     "PauseInfoManual": {
       "type": "object",
       "properties": {
@@ -7513,9 +7534,9 @@
           "type": "string",
           "description": "Only the activity with this ID will be paused."
         },
-        "type": {
-          "type": "string",
-          "description": "Pause all running activities of this type."
+        "pauseByType": {
+          "$ref": "#/definitions/PauseActivityRequestPauseByType",
+          "description": "Pause by type with option to pause all, running, or future activities of this type."
         },
         "reason": {
           "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9081,12 +9081,26 @@ components:
         id:
           type: string
           description: Only the activity with this ID will be paused.
-        type:
-          type: string
-          description: Pause all running activities of this type.
+        pauseByType:
+          allOf:
+            - $ref: '#/components/schemas/PauseActivityRequest_PauseByType'
+          description: Pause by type with option to pause all, running, or future activities of this type.
         reason:
           type: string
           description: Reason to pause the activity.
+    PauseActivityRequest_PauseByType:
+      type: object
+      properties:
+        name:
+          type: string
+        option:
+          enum:
+            - PAUSE_BY_TYPE_OPTION_UNSPECIFIED
+            - PAUSE_BY_TYPE_OPTION_ALL
+            - PAUSE_BY_TYPE_OPTION_RUNNING
+            - PAUSE_BY_TYPE_OPTION_FUTURE
+          type: string
+          format: enum
     PauseActivityResponse:
       type: object
       properties: {}

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9083,10 +9083,22 @@ components:
           description: Only the activity with this ID will be paused.
         type:
           type: string
-          description: Pause all running activities of this type.
+          description: Pause activities of this type.
+        pauseAll:
+          type: boolean
+          description: Pause all activities.
         reason:
           type: string
           description: Reason to pause the activity.
+        activityState:
+          enum:
+            - PAUSE_OPTION_ACTIVITY_STATE_UNSPECIFIED
+            - PAUSE_OPTION_ACTIVITY_STATE_RUNNING
+            - PAUSE_OPTION_ACTIVITY_STATE_FUTURE
+            - PAUSE_OPTION_ACTIVITY_STATE_BOTH
+          type: string
+          description: which activities to pause - current, future or both.
+          format: enum
     PauseActivityResponse:
       type: object
       properties: {}
@@ -11989,10 +12001,10 @@ components:
           description: Only the activity with this ID will be unpaused.
         type:
           type: string
-          description: Unpause all running activities with of this type.
+          description: Unpause activities of this type.
         unpauseAll:
           type: boolean
-          description: Unpause all running activities.
+          description: Unpause all activities.
         resetAttempts:
           type: boolean
           description: Providing this flag will also reset the number of attempts.
@@ -12003,6 +12015,15 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: If set, the activity will start at a random time within the specified jitter duration.
+        activityState:
+          enum:
+            - PAUSE_OPTION_ACTIVITY_STATE_UNSPECIFIED
+            - PAUSE_OPTION_ACTIVITY_STATE_RUNNING
+            - PAUSE_OPTION_ACTIVITY_STATE_FUTURE
+            - PAUSE_OPTION_ACTIVITY_STATE_BOTH
+          type: string
+          description: which activities to unpause - current, future or both.
+          format: enum
     UnpauseActivityResponse:
       type: object
       properties: {}

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9081,26 +9081,12 @@ components:
         id:
           type: string
           description: Only the activity with this ID will be paused.
-        pauseByType:
-          allOf:
-            - $ref: '#/components/schemas/PauseActivityRequest_PauseByType'
-          description: Pause by type with option to pause all, running, or future activities of this type.
+        type:
+          type: string
+          description: Pause all running activities of this type.
         reason:
           type: string
           description: Reason to pause the activity.
-    PauseActivityRequest_PauseByType:
-      type: object
-      properties:
-        name:
-          type: string
-        option:
-          enum:
-            - PAUSE_BY_TYPE_OPTION_UNSPECIFIED
-            - PAUSE_BY_TYPE_OPTION_ALL
-            - PAUSE_BY_TYPE_OPTION_RUNNING
-            - PAUSE_BY_TYPE_OPTION_FUTURE
-          type: string
-          format: enum
     PauseActivityResponse:
       type: object
       properties: {}

--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -162,10 +162,10 @@ enum VersioningBehavior {
     VERSIONING_BEHAVIOR_AUTO_UPGRADE = 2;
 }
 
-// Pause option activity status is used to specify if we want to pause/unpause just the current activity, or just the future activities or both.
-enum PauseOptionActivityStatus {
-    PAUSE_OPTION_ACTIVITY_STATUS_UNSPECIFIED = 0;
-    PAUSE_OPTION_ACTIVITY_STATUS_RUNNING = 1;
-    PAUSE_OPTION_ACTIVITY_STATUS_FUTURE = 2;
-    PAUSE_OPTION_ACTIVITY_STATUS_BOTH = 3;
+// Pause option activity state is used to specify if we want to pause/unpause just the current activity, or just the future activities or both.
+enum PauseOptionActivityState {
+    PAUSE_OPTION_ACTIVITY_STATE_UNSPECIFIED = 0;
+    PAUSE_OPTION_ACTIVITY_STATE_RUNNING = 1;
+    PAUSE_OPTION_ACTIVITY_STATE_FUTURE = 2;
+    PAUSE_OPTION_ACTIVITY_STATE_BOTH = 3;
 }

--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -161,3 +161,11 @@ enum VersioningBehavior {
     // complete on the old Version.
     VERSIONING_BEHAVIOR_AUTO_UPGRADE = 2;
 }
+
+// Pause option activity status is used to specify if we want to pause/unpause just the current activity, or just the future activities or both.
+enum PauseOptionActivityStatus {
+    PAUSE_OPTION_ACTIVITY_STATUS_UNSPECIFIED = 0;
+    PAUSE_OPTION_ACTIVITY_STATUS_RUNNING = 1;
+    PAUSE_OPTION_ACTIVITY_STATUS_FUTURE = 2;
+    PAUSE_OPTION_ACTIVITY_STATUS_BOTH = 3;
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1905,12 +1905,28 @@ message PauseActivityRequest {
     oneof activity {
         // Only the activity with this ID will be paused.
         string id = 4;
-        // Pause all running activities of this type.
-        string type = 5;
+        // Pause by type with option to pause all, running, or future activities of this type.
+        // (-- api-linter: core::0140::prepositions=disabled --)
+        PauseByType pause_by_type = 7;
     }
+    reserved 5;
+    reserved "type";
 
     // Reason to pause the activity.
     string reason = 6;
+
+    // (-- api-linter: core::0123::resource-annotation=disabled --)
+    message PauseByType{
+        string name = 1;
+        PauseByTypeOption option = 2;
+    }
+
+    enum PauseByTypeOption{
+        PAUSE_BY_TYPE_OPTION_UNSPECIFIED = 0;
+        PAUSE_BY_TYPE_OPTION_ALL = 1;
+        PAUSE_BY_TYPE_OPTION_RUNNING = 2;
+        PAUSE_BY_TYPE_OPTION_FUTURE = 3;
+    }
 }
 
 message PauseActivityResponse {
@@ -1980,6 +1996,7 @@ message ResetActivityRequest {
     // Default options are then options activity was created with.
     // They are part of the first SCHEDULE event.
     bool restore_original_options = 9;
+
 
 }
 
@@ -2208,8 +2225,8 @@ message ListWorkerDeploymentsResponse {
         google.protobuf.Timestamp create_time = 2;
         temporal.api.deployment.v1.RoutingConfig routing_config = 3;
         // Summary of the version that was added most recently in the Worker Deployment.
-        temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary latest_version_summary = 4; 
-        // Summary of the current version of the Worker Deployment. 
+        temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary latest_version_summary = 4;
+        // Summary of the current version of the Worker Deployment.
         temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary current_version_summary = 5;
         // Summary of the ramping version of the Worker Deployment.
         temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary ramping_version_summary = 6;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1905,12 +1905,17 @@ message PauseActivityRequest {
     oneof activity {
         // Only the activity with this ID will be paused.
         string id = 4;
-        // Pause all running activities of this type.
+        // Pause activities of this type.
         string type = 5;
+        // Pause all activities.
+        bool pause_all = 7;
     }
 
     // Reason to pause the activity.
     string reason = 6;
+
+    // which activities to pause - current, future or both.
+    temporal.api.enums.v1.PauseOptionActivityStatus activity_status = 8;
 }
 
 message PauseActivityResponse {
@@ -1929,9 +1934,9 @@ message UnpauseActivityRequest {
     oneof activity {
         // Only the activity with this ID will be unpaused.
         string id = 4;
-        // Unpause all running activities with of this type.
+        // Unpause activities of this type.
         string type = 5;
-        // Unpause all running activities.
+        // Unpause all activities.
         bool unpause_all = 6;
     }
 
@@ -1943,6 +1948,9 @@ message UnpauseActivityRequest {
 
     // If set, the activity will start at a random time within the specified jitter duration.
     google.protobuf.Duration jitter = 9;
+
+    // which activities to unpause - current, future or both.
+    temporal.api.enums.v1.PauseOptionActivityStatus activity_status = 10;
 }
 
 message UnpauseActivityResponse {
@@ -2208,8 +2216,8 @@ message ListWorkerDeploymentsResponse {
         google.protobuf.Timestamp create_time = 2;
         temporal.api.deployment.v1.RoutingConfig routing_config = 3;
         // Summary of the version that was added most recently in the Worker Deployment.
-        temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary latest_version_summary = 4; 
-        // Summary of the current version of the Worker Deployment. 
+        temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary latest_version_summary = 4;
+        // Summary of the current version of the Worker Deployment.
         temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary current_version_summary = 5;
         // Summary of the ramping version of the Worker Deployment.
         temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary ramping_version_summary = 6;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1915,7 +1915,7 @@ message PauseActivityRequest {
     string reason = 6;
 
     // which activities to pause - current, future or both.
-    temporal.api.enums.v1.PauseOptionActivityStatus activity_status = 8;
+    temporal.api.enums.v1.PauseOptionActivityState activity_state = 8;
 }
 
 message PauseActivityResponse {
@@ -1950,7 +1950,7 @@ message UnpauseActivityRequest {
     google.protobuf.Duration jitter = 9;
 
     // which activities to unpause - current, future or both.
-    temporal.api.enums.v1.PauseOptionActivityStatus activity_status = 10;
+    temporal.api.enums.v1.PauseOptionActivityState activity_state = 10;
 }
 
 message UnpauseActivityResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1905,28 +1905,12 @@ message PauseActivityRequest {
     oneof activity {
         // Only the activity with this ID will be paused.
         string id = 4;
-        // Pause by type with option to pause all, running, or future activities of this type.
-        // (-- api-linter: core::0140::prepositions=disabled --)
-        PauseByType pause_by_type = 7;
+        // Pause all running activities of this type.
+        string type = 5;
     }
-    reserved 5;
-    reserved "type";
 
     // Reason to pause the activity.
     string reason = 6;
-
-    // (-- api-linter: core::0123::resource-annotation=disabled --)
-    message PauseByType{
-        string name = 1;
-        PauseByTypeOption option = 2;
-    }
-
-    enum PauseByTypeOption{
-        PAUSE_BY_TYPE_OPTION_UNSPECIFIED = 0;
-        PAUSE_BY_TYPE_OPTION_ALL = 1;
-        PAUSE_BY_TYPE_OPTION_RUNNING = 2;
-        PAUSE_BY_TYPE_OPTION_FUTURE = 3;
-    }
 }
 
 message PauseActivityResponse {
@@ -1996,7 +1980,6 @@ message ResetActivityRequest {
     // Default options are then options activity was created with.
     // They are part of the first SCHEDULE event.
     bool restore_original_options = 9;
-
 
 }
 
@@ -2225,8 +2208,8 @@ message ListWorkerDeploymentsResponse {
         google.protobuf.Timestamp create_time = 2;
         temporal.api.deployment.v1.RoutingConfig routing_config = 3;
         // Summary of the version that was added most recently in the Worker Deployment.
-        temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary latest_version_summary = 4;
-        // Summary of the current version of the Worker Deployment.
+        temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary latest_version_summary = 4; 
+        // Summary of the current version of the Worker Deployment. 
         temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary current_version_summary = 5;
         // Summary of the ramping version of the Worker Deployment.
         temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary ramping_version_summary = 6;


### PR DESCRIPTION

We decided to support pausing of activities by type with the following options:
 - All: Pause all running and future activities of the given type.
 - Running: Pause just the currently running activities.
 - Future: Pause just the future activities if the given type.

<!-- Tell your future self why have you made these changes -->
This is to support different options while pausing by activity type.


