### PR TITLE
Update descriptions of WorkflowService and OperatorService

### DIFF
--- a/temporal/api/operatorservice/v1/service.proto
+++ b/temporal/api/operatorservice/v1/service.proto
@@ -13,10 +13,10 @@ option csharp_namespace = "Temporalio.Api.OperatorService.V1";
 import "temporal/api/operatorservice/v1/request_response.proto";
 import "google/api/annotations.proto";
 
-// OperatorService API defines how Temporal SDKs and other clients interact with the Temporal server
-// to perform administrative functions like registering a search attribute or a namespace.
-// APIs in this file could be not compatible with Temporal Cloud, hence it's usage in SDKs should be limited by
-// designated APIs that clearly state that they shouldn't be used by the main Application (Workflows & Activities) framework.
+// The OperatorService API defines how Temporal SDKs and other clients interact with the Temporal server to
+// perform administrative functions. APIs in this file may be incompatible with Temporal Cloud, hence its
+// usage in SDKs should be limited to APIs that clearly state that they shouldn't be used by the main
+// application framework (Workflows, Nexus Operations, etc)
 service OperatorService {
     // (-- Search Attribute --)
 
@@ -44,6 +44,7 @@ service OperatorService {
     }
 
     // DeleteNamespace synchronously deletes a namespace and asynchronously reclaims all namespace resources.
+    // See workflowservice for other operations on namespaces.
     rpc DeleteNamespace (DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
     }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -13,8 +13,9 @@ option csharp_namespace = "Temporalio.Api.WorkflowService.V1";
 import "temporal/api/workflowservice/v1/request_response.proto";
 import "google/api/annotations.proto";
 
-// WorkflowService API defines how Temporal SDKs and other clients interact with the Temporal server
-// to create and interact with workflows and activities.
+// The WorkflowService API defines how Temporal SDKs and other clients interact with the
+// Temporal server to perform operations against entities including namespaces, workflows,
+// activities, schedules, and nexus operations.
 //
 // Users are expected to call `StartWorkflowExecution` to create a new workflow execution.
 //


### PR DESCRIPTION
Small improvements to descriptions of the services. E.g.
- OperatorService docstrings were falsely claiming that it included namespace registration
- WorkflowService was failing to document the diversity of APIs that it now supports