### PR TITLE
Allow SetCurrent and SetRamping to a version that has never seen pollers, if opt in

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -8392,6 +8392,10 @@
         "ignoreMissingTaskQueues": {
           "type": "boolean",
           "description": "Optional. By default this request would be rejected if not all the expected Task Queues are\nbeing polled by the new Version, to protect against accidental removal of Task Queues, or\nworker health issues. Pass `true` here to bypass this protection.\nThe set of expected Task Queues is the set of all the Task Queues that were ever poller by\nthe existing Current Version of the Deployment, with the following exclusions:\n  - Task Queues that are not used anymore (inferred by having empty backlog and a task\n    add_rate of 0.)\n  - Task Queues that are moved to another Worker Deployment (inferred by the Task Queue\n    having a different Current Version than the Current Version of this deployment.)\nWARNING: Do not set this flag unless you are sure that the missing task queue pollers are not\nneeded. If the request is unexpectedly rejected due to missing pollers, then that means the\npollers have not reached to the server yet. Only set this if you expect those pollers to\nnever arrive."
+        },
+        "allowNoPollers": {
+          "type": "boolean",
+          "description": "Optional. By default this request will be rejected if no pollers have been seen for the proposed\nCurrent Version, in order to protect users from routing tasks to pollers that do not exist, leading\nto possible timeouts. Pass `true` here to bypass this protection."
         }
       },
       "description": "Set/unset the Current Version of a Worker Deployment."
@@ -8424,6 +8428,10 @@
         "ignoreMissingTaskQueues": {
           "type": "boolean",
           "description": "Optional. By default this request would be rejected if not all the expected Task Queues are\nbeing polled by the new Version, to protect against accidental removal of Task Queues, or\nworker health issues. Pass `true` here to bypass this protection.\nThe set of expected Task Queues equals to all the Task Queues ever polled from the existing\nCurrent Version of the Deployment, with the following exclusions:\n  - Task Queues that are not used anymore (inferred by having empty backlog and a task\n    add_rate of 0.)\n  - Task Queues that are moved to another Worker Deployment (inferred by the Task Queue\n    having a different Current Version than the Current Version of this deployment.)\nWARNING: Do not set this flag unless you are sure that the missing task queue poller are not\nneeded. If the request is unexpectedly rejected due to missing pollers, then that means the\npollers have not reached to the server yet. Only set this if you expect those pollers to\nnever arrive.\nNote: this check only happens when the ramping version is about to change, not every time\nthat the percentage changes. Also note that the check is against the deployment's Current\nVersion, not the previous Ramping Version."
+        },
+        "allowNoPollers": {
+          "type": "boolean",
+          "description": "Optional. By default this request will be rejected if no pollers have been seen for the proposed\nCurrent Version, in order to protect users from routing tasks to pollers that do not exist, leading\nto possible timeouts. Pass `true` here to bypass this protection."
         }
       },
       "description": "Set/unset the Ramping Version of a Worker Deployment and its ramp percentage."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11423,6 +11423,12 @@ components:
              needed. If the request is unexpectedly rejected due to missing pollers, then that means the
              pollers have not reached to the server yet. Only set this if you expect those pollers to
              never arrive.
+        allowNoPollers:
+          type: boolean
+          description: |-
+            Optional. By default this request will be rejected if no pollers have been seen for the proposed
+             Current Version, in order to protect users from routing tasks to pollers that do not exist, leading
+             to possible timeouts. Pass `true` here to bypass this protection.
       description: Set/unset the Current Version of a Worker Deployment.
     SetWorkerDeploymentCurrentVersionResponse:
       type: object
@@ -11491,6 +11497,12 @@ components:
              Note: this check only happens when the ramping version is about to change, not every time
              that the percentage changes. Also note that the check is against the deployment's Current
              Version, not the previous Ramping Version.
+        allowNoPollers:
+          type: boolean
+          description: |-
+            Optional. By default this request will be rejected if no pollers have been seen for the proposed
+             Current Version, in order to protect users from routing tasks to pollers that do not exist, leading
+             to possible timeouts. Pass `true` here to bypass this protection.
       description: Set/unset the Ramping Version of a Worker Deployment and its ramp percentage.
     SetWorkerDeploymentRampingVersionResponse:
       type: object

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2165,6 +2165,10 @@ message SetWorkerDeploymentCurrentVersionRequest {
     // pollers have not reached to the server yet. Only set this if you expect those pollers to
     // never arrive.
     bool ignore_missing_task_queues = 6;
+    // Optional. By default this request will be rejected if no pollers have been seen for the proposed
+    // Current Version, in order to protect users from routing tasks to pollers that do not exist, leading
+    // to possible timeouts. Pass `true` here to bypass this protection.
+    bool allow_no_pollers = 9;
 }
 
 message SetWorkerDeploymentCurrentVersionResponse {
@@ -2217,6 +2221,10 @@ message SetWorkerDeploymentRampingVersionRequest {
     // that the percentage changes. Also note that the check is against the deployment's Current
     // Version, not the previous Ramping Version.
     bool ignore_missing_task_queues = 7;
+    // Optional. By default this request will be rejected if no pollers have been seen for the proposed
+    // Current Version, in order to protect users from routing tasks to pollers that do not exist, leading
+    // to possible timeouts. Pass `true` here to bypass this protection.
+    bool allow_no_pollers = 10;
 }
 
 message SetWorkerDeploymentRampingVersionResponse {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
Allow SetCurrent and SetRamping to a version that has never seen pollers, if opt in


<!-- Tell your future self why have you made these changes -->
So that users can call SetCurrent or SetRamping as part of their Deployment pipelines, before the workers have actually been deployed and started polling. This should only be available to users who opt in and understand that their tasks won't be picked up until the pollers arrive.

This has been requested by multiple users.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
