### PR TITLE
Updated proto with API changes

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -17957,6 +17957,10 @@
           "type": "integer",
           "format": "int32",
           "title": "Starting at 1, how many attempts there have been to complete this task"
+        },
+        "scheduleToStartTimeout": {
+          "type": "string",
+          "description": "Limits time a workflow task can stay in a task queue before a worker picks it up.\nOnly set when the server enforces a schedule-to-start timeout (e.g. sticky or speculative WT on normal queue).\n"
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16718,6 +16718,15 @@ components:
           type: integer
           description: Starting at 1, how many attempts there have been to complete this task
           format: int32
+        scheduleToStartTimeout:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            Limits time a workflow task can stay in a task queue before a worker picks it up.
+             Only set when the server enforces a schedule-to-start timeout (e.g. sticky or speculative WT on normal queue).
+
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: "to" is used to indicate interval. --)
     WorkflowTaskStartedEventAttributes:
       type: object
       properties:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -261,6 +261,13 @@ message WorkflowTaskScheduledEventAttributes {
     google.protobuf.Duration start_to_close_timeout = 2;
     // Starting at 1, how many attempts there have been to complete this task
     int32 attempt = 3;
+    // Limits time a workflow task can stay in a task queue before a worker picks it up.
+    // Only set when the server enforces a schedule-to-start timeout (e.g. sticky or speculative WT on normal queue).
+    //
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "to" is used to indicate interval. --)
+    google.protobuf.Duration schedule_to_start_timeout = 4;
+
 }
 
 message WorkflowTaskStartedEventAttributes {


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**
Added optional schedule_to_start_timeout (google.protobuf.Duration, field number 4) to WorkflowTaskScheduledEventAttributes in temporal/api/history/v1/message.proto.
Regenerated Go and OpenAPI in this repo (via make proto / project tooling).

<!-- Tell your future self why have you made these changes -->
**Why?**

Fixes temporalio/temporal#778: the server applies a schedule-to-start timeout (e.g. 5s for speculative workflow tasks, or the sticky timeout) but the event did not record it, so UIs could show a different value (e.g. 10s) and users were confused when the task timed out earlier. Storing the timeout on the event makes the server’s behavior visible and consistent for clients and UIs.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

None. New field is optional; existing events and clients remain valid.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**

Server PR (to temporalio/temporal) that populates and uses this field: https://github.com/temporalio/temporal/pull/9257