### PR TITLE
Future proof ListWorkersResponse

### DIFF
--- a/temporal/api/worker/v1/message.proto
+++ b/temporal/api/worker/v1/message.proto
@@ -139,3 +139,48 @@ message PluginInfo {
     // The version of the plugin, may be empty.
     string version = 2;
 }
+
+message WorkerListInfo {
+  // Worker identifier, should be unique for the namespace.
+  // It is distinct from worker identity, which is not necessarily namespace-unique.
+  string worker_instance_key = 1;
+
+  // Worker identity, set by the client, may not be unique.
+  // Usually host_name+(user group name)+process_id, but can be overwritten by the user.
+  string worker_identity = 2;
+
+  // Worker host information.
+  WorkerHostInfo host_info = 3;
+
+  // Task queue this worker is polling for tasks.
+  string task_queue = 4;
+
+  temporal.api.deployment.v1.WorkerDeploymentVersion deployment_version = 5;
+
+  string sdk_name = 6;
+  string sdk_version = 7;
+
+  // Worker status. Defined by SDK.
+  // (perhaps excluding shutdown vs. shutting down).
+  temporal.api.enums.v1.WorkerStatus status = 8;
+
+  // Worker start time.
+  // It can be used to determine worker uptime. (current time - start time)
+  google.protobuf.Timestamp start_time = 9;
+
+  // Worker host identifier.
+  string host_name = 10;
+
+  // Worker grouping identifier. A key to group workers that share the same client+namespace+process.
+  // This will be used to build the worker command nexus task queue name:
+  // "temporal-sys/worker-commands/{worker_grouping_key}"
+  string worker_grouping_key = 11;
+
+  // Worker process identifier. This id only needs to be unique
+  // within one host (so using e.g. a unix pid would be appropriate).
+  string process_id = 12;
+
+  // Plugins currently in use by this SDK.
+  repeated PluginInfo plugins = 13;
+}
+

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2563,14 +2563,17 @@ message ListWorkersRequest {
     //* SdkName
     //* SdkVersion
     //* StartTime
-    //* LastHeartbeatTime
-    //* Status
-    // Currently metrics are not supported as a part of ListWorkers query.
+    //* Status ??? (perhaps excluding shutdown vs. shutting down).
+    //* Any user custom search attribute - future work
+    // Metrics are not supported as a part of ListWorkers query.
     string query = 4;
 }
 
 message ListWorkersResponse {
+    // Deprecated. Use workers instead.
     repeated temporal.api.worker.v1.WorkerInfo workers_info = 1;
+
+    repeated temporal.api.worker.v1.WorkerListInfo workers = 2;
 
     // Next page token
     bytes next_page_token = 2;


### PR DESCRIPTION
**What changed?**

Add `WorkerListInfo` to be returned by the `ListWorkersResponse` with a minimal set of static attributes.

**Why?**

We are likely to change the backing store for the collection of workers to visibility, which doesn't support frequent updates.

**Breaking changes**

None, but the old fields have been deprecated (for now).

**Server PR**

Not available yet.