### PR TITLE
Remove buf ignore that was used to retag worker_instance_key

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -16,8 +16,6 @@ breaking:
     - temporal/api/enums/v1/failed_cause.proto
     # TODO: remove this once the changes with WorkflowExecutionExtendedInfo.pause_info is merged
     - temporal/api/workflow/v1/message.proto
-    # TODO (amazzeo): remove this once worker_instance_key has successfully been retagged in PollWorkflowTaskQueueRequest and PollActivityTaskQueueRequest
-    - temporal/api/workflowservice/v1/request_response.proto
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
_**READ BEFORE MERGING:** All PRs require approval by both Server AND SDK teams before merging! This is why the number of required approvals is "2" and not "1"--two reviewers from the same team is NOT sufficient. If your PR is not approved by someone in BOTH teams, it may be summarily reverted._

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
