### PR TITLE
Add CountWorkers API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -2190,6 +2190,44 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/worker-count": {
+      "get": {
+        "summary": "CountWorkers is a visibility API to count workers in a specific namespace.",
+        "operationId": "CountWorkers2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CountWorkersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "description": "Query to filter workers before counting.\nSupported filter fields are the same as in ListWorkersRequest.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/worker-deployment-versions/{deploymentVersion.deploymentName}/{deploymentVersion.buildId}": {
       "get": {
         "summary": "Describes a worker deployment version.\nExperimental. This API might significantly change or be removed in a future release.",
@@ -6682,6 +6720,44 @@
             "name": "taskQueue",
             "in": "path",
             "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/worker-count": {
+      "get": {
+        "summary": "CountWorkers is a visibility API to count workers in a specific namespace.",
+        "operationId": "CountWorkers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CountWorkersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "description": "Query to filter workers before counting.\nSupported filter fields are the same as in ListWorkersRequest.",
+            "in": "query",
+            "required": false,
             "type": "string"
           }
         ],
@@ -11951,6 +12027,16 @@
         "count": {
           "type": "string",
           "format": "int64"
+        }
+      }
+    },
+    "v1CountWorkersResponse": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "string",
+          "format": "int64",
+          "description": "Approximate number of workers matching the query."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12036,7 +12036,7 @@
         "count": {
           "type": "string",
           "format": "int64",
-          "description": "Approximate number of workers matching the query."
+          "description": "Number of workers matching the query."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -2786,6 +2786,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "includeSystemWorkers",
+            "description": "When true, the count will include system workers that are created implicitly\nby the server and not by the user. By default, system workers are excluded.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -8313,6 +8320,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "includeSystemWorkers",
+            "description": "When true, the count will include system workers that are created implicitly\nby the server and not by the user. By default, system workers are excluded.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -2192,7 +2192,7 @@
     },
     "/api/v1/namespaces/{namespace}/worker-count": {
       "get": {
-        "summary": "CountWorkers is a visibility API to count workers in a specific namespace.",
+        "summary": "CountWorkers counts the number of workers in a specific namespace.",
         "operationId": "CountWorkers2",
         "responses": {
           "200": {
@@ -6730,7 +6730,7 @@
     },
     "/namespaces/{namespace}/worker-count": {
       "get": {
-        "summary": "CountWorkers is a visibility API to count workers in a specific namespace.",
+        "summary": "CountWorkers counts the number of workers in a specific namespace.",
         "operationId": "CountWorkers",
         "responses": {
           "200": {

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1958,6 +1958,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/worker-count:
+    get:
+      tags:
+        - WorkflowService
+      description: CountWorkers is a visibility API to count workers in a specific namespace.
+      operationId: CountWorkers
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: query
+          in: query
+          description: |-
+            Query to filter workers before counting.
+             Supported filter fields are the same as in ListWorkersRequest.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CountWorkersResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/worker-deployment-versions/{deployment_version.deployment_name}/{deployment_version.build_id}:
     get:
       tags:
@@ -5991,6 +6023,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/worker-count:
+    get:
+      tags:
+        - WorkflowService
+      description: CountWorkers is a visibility API to count workers in a specific namespace.
+      operationId: CountWorkers
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: query
+          in: query
+          description: |-
+            Query to filter workers before counting.
+             Supported filter fields are the same as in ListWorkersRequest.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CountWorkersResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/worker-deployment-versions/{deployment_version.deployment_name}/{deployment_version.build_id}:
     get:
       tags:
@@ -9100,6 +9164,12 @@ components:
             $ref: '#/components/schemas/Payload'
         count:
           type: string
+    CountWorkersResponse:
+      type: object
+      properties:
+        count:
+          type: string
+          description: Approximate number of workers matching the query.
     CountWorkflowExecutionsResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -1962,7 +1962,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: CountWorkers is a visibility API to count workers in a specific namespace.
+      description: CountWorkers counts the number of workers in a specific namespace.
       operationId: CountWorkers
       parameters:
         - name: namespace
@@ -6027,7 +6027,7 @@ paths:
     get:
       tags:
         - WorkflowService
-      description: CountWorkers is a visibility API to count workers in a specific namespace.
+      description: CountWorkers counts the number of workers in a specific namespace.
       operationId: CountWorkers
       parameters:
         - name: namespace

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -2506,6 +2506,13 @@ paths:
              Supported filter fields are the same as in ListWorkersRequest.
           schema:
             type: string
+        - name: includeSystemWorkers
+          in: query
+          description: |-
+            When true, the count will include system workers that are created implicitly
+             by the server and not by the user. By default, system workers are excluded.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -7495,6 +7502,13 @@ paths:
              Supported filter fields are the same as in ListWorkersRequest.
           schema:
             type: string
+        - name: includeSystemWorkers
+          in: query
+          description: |-
+            When true, the count will include system workers that are created implicitly
+             by the server and not by the user. By default, system workers are excluded.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9169,7 +9169,7 @@ components:
       properties:
         count:
           type: string
-          description: Approximate number of workers matching the query.
+          description: Number of workers matching the query.
     CountWorkflowExecutionsResponse:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2684,6 +2684,18 @@ message DescribeWorkerResponse {
     temporal.api.worker.v1.WorkerInfo worker_info = 1;
 }
 
+message CountWorkersRequest {
+    string namespace = 1;
+    // Query to filter workers before counting.
+    // Supported filter fields are the same as in ListWorkersRequest.
+    string query = 2;
+}
+
+message CountWorkersResponse {
+    // Approximate number of workers matching the query.
+    int64 count = 1;
+}
+
 // Request to pause a workflow execution.
 message PauseWorkflowExecutionRequest {
     // Namespace of the workflow to pause.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3067,6 +3067,9 @@ message CountWorkersRequest {
     // Query to filter workers before counting.
     // Supported filter fields are the same as in ListWorkersRequest.
     string query = 2;
+    // When true, the count will include system workers that are created implicitly
+    // by the server and not by the user. By default, system workers are excluded.
+    bool include_system_workers = 3;
 }
 
 message CountWorkersResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2692,7 +2692,7 @@ message CountWorkersRequest {
 }
 
 message CountWorkersResponse {
-    // Approximate number of workers matching the query.
+    // Number of workers matching the query.
     int64 count = 1;
 }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -1272,6 +1272,16 @@ service WorkflowService {
         };
     }
 
+    // CountWorkers is a visibility API to count workers in a specific namespace.
+    rpc CountWorkers (CountWorkersRequest) returns (CountWorkersResponse) {
+        option (google.api.http) = {
+            get: "/namespaces/{namespace}/worker-count"
+            additional_bindings {
+                get: "/api/v1/namespaces/{namespace}/worker-count"
+            }
+        };
+    }
+
     // Updates task queue configuration.
     // For the overall queue rate limit: the rate limit set by this api overrides the worker-set rate limit,
     // which uncouples the rate limit from the worker lifecycle.

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -1272,7 +1272,7 @@ service WorkflowService {
         };
     }
 
-    // CountWorkers is a visibility API to count workers in a specific namespace.
+    // CountWorkers counts the number of workers in a specific namespace.
     rpc CountWorkers (CountWorkersRequest) returns (CountWorkersResponse) {
         option (google.api.http) = {
             get: "/namespaces/{namespace}/worker-count"


### PR DESCRIPTION
## What
Add `CountWorkers` RPC to `WorkflowService` for counting workers matching a query filter.

- Request: `namespace` + `query` + `include_system_workers` (same filter fields as `ListWorkers`)
- Response: `int64 count`
- HTTP route: `GET /namespaces/{namespace}/worker-count`

[Server PR](https://github.com/temporalio/temporal/pull/9476)

## Why
The worker UI needs to display a total worker count (e.g. in tabs) without fetching the full list. Follows the established pattern used by `CountWorkflowExecutions`, `CountSchedules`, and `CountActivityExecutions`.

## How did you test it?
- [x] built (`make ci-build`)
- [x] passes buf linting and breaking change checks
- [x] regenerated OpenAPI specs