### PR TITLE
Add completed_by_worker_shutdown field to poll responses

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -14580,6 +14580,10 @@
         "pollerScalingDecision": {
           "$ref": "#/definitions/v1PollerScalingDecision",
           "description": "Server-advised information the SDK may use to adjust its poller count."
+        },
+        "shutdownWorkerRejected": {
+          "type": "boolean",
+          "description": "When true, this empty response was caused by the server rejecting the poll\nbecause the worker has been shut down via the ShutdownWorker API. The SDK\nshould stop polling on this task queue."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15356,9 +15356,9 @@
           "$ref": "#/definitions/v1PollerScalingDecision",
           "description": "Server-advised information the SDK may use to adjust its poller count."
         },
-        "shutdownWorkerRejected": {
+        "completedByWorkerShutdown": {
           "type": "boolean",
-          "description": "When true, this empty response was caused by the server rejecting the poll\nbecause the worker has been shut down via the ShutdownWorker API. The SDK\nshould stop polling on this task queue."
+          "description": "When true, this empty response was caused by the server completing the poll\nbecause the worker has been shut down via the ShutdownWorker API. The SDK\nshould stop polling on this task queue.\n"
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12220,12 +12220,15 @@ components:
           allOf:
             - $ref: '#/components/schemas/PollerScalingDecision'
           description: Server-advised information the SDK may use to adjust its poller count.
-        shutdownWorkerRejected:
+        completedByWorkerShutdown:
           type: boolean
           description: |-
-            When true, this empty response was caused by the server rejecting the poll
+            When true, this empty response was caused by the server completing the poll
              because the worker has been shut down via the ShutdownWorker API. The SDK
              should stop polling on this task queue.
+
+             (-- api-linter: core::0140::prepositions=disabled
+                 aip.dev/not-precedent: "by" describes the cause of poll completion. --)
     PollerInfo:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11640,6 +11640,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/PollerScalingDecision'
           description: Server-advised information the SDK may use to adjust its poller count.
+        shutdownWorkerRejected:
+          type: boolean
+          description: |-
+            When true, this empty response was caused by the server rejecting the poll
+             because the worker has been shut down via the ShutdownWorker API. The SDK
+             should stop polling on this task queue.
     PollerInfo:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -338,10 +338,13 @@ message PollWorkflowTaskQueueResponse {
     repeated temporal.api.protocol.v1.Message messages = 15;
     // Server-advised information the SDK may use to adjust its poller count.
     temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 16;
-    // When true, this empty response was caused by the server rejecting the poll
+    // When true, this empty response was caused by the server completing the poll
     // because the worker has been shut down via the ShutdownWorker API. The SDK
     // should stop polling on this task queue.
-    bool shutdown_worker_rejected = 17;
+    //
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "by" describes the cause of poll completion. --)
+    bool completed_by_worker_shutdown = 17;
 }
 
 message RespondWorkflowTaskCompletedRequest {
@@ -540,10 +543,13 @@ message PollActivityTaskQueueResponse {
     temporal.api.common.v1.Priority priority = 19;
     // The run ID of the activity execution, only set for standalone activities.
     string activity_run_id = 20;
-    // When true, this empty response was caused by the server rejecting the poll
+    // When true, this empty response was caused by the server completing the poll
     // because the worker has been shut down via the ShutdownWorker API. The SDK
     // should stop polling on this task queue.
-    bool shutdown_worker_rejected = 21;
+    //
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "by" describes the cause of poll completion. --)
+    bool completed_by_worker_shutdown = 21;
 }
 
 message RecordActivityTaskHeartbeatRequest {
@@ -1931,10 +1937,13 @@ message PollNexusTaskQueueResponse {
     temporal.api.nexus.v1.Request request = 2;
     // Server-advised information the SDK may use to adjust its poller count.
     temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 3;
-    // When true, this empty response was caused by the server rejecting the poll
+    // When true, this empty response was caused by the server completing the poll
     // because the worker has been shut down via the ShutdownWorker API. The SDK
     // should stop polling on this task queue.
-    bool shutdown_worker_rejected = 4;
+    //
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: "by" describes the cause of poll completion. --)
+    bool completed_by_worker_shutdown = 4;
 }
 
 message RespondNexusTaskCompletedRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -331,6 +331,10 @@ message PollWorkflowTaskQueueResponse {
     repeated temporal.api.protocol.v1.Message messages = 15;
     // Server-advised information the SDK may use to adjust its poller count.
     temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 16;
+    // When true, this empty response was caused by the server rejecting the poll
+    // because the worker has been shut down via the ShutdownWorker API. The SDK
+    // should stop polling on this task queue.
+    bool shutdown_worker_rejected = 17;
 }
 
 message RespondWorkflowTaskCompletedRequest {
@@ -516,6 +520,10 @@ message PollActivityTaskQueueResponse {
     temporal.api.common.v1.Priority priority = 19;
     // The run ID of the activity execution, only set for standalone activities.
     string activity_run_id = 20;
+    // When true, this empty response was caused by the server rejecting the poll
+    // because the worker has been shut down via the ShutdownWorker API. The SDK
+    // should stop polling on this task queue.
+    bool shutdown_worker_rejected = 21;
 }
 
 message RecordActivityTaskHeartbeatRequest {
@@ -1892,6 +1900,10 @@ message PollNexusTaskQueueResponse {
     temporal.api.nexus.v1.Request request = 2;
     // Server-advised information the SDK may use to adjust its poller count.
     temporal.api.taskqueue.v1.PollerScalingDecision poller_scaling_decision = 3;
+    // When true, this empty response was caused by the server rejecting the poll
+    // because the worker has been shut down via the ShutdownWorker API. The SDK
+    // should stop polling on this task queue.
+    bool shutdown_worker_rejected = 4;
 }
 
 message RespondNexusTaskCompletedRequest {


### PR DESCRIPTION
## What changed?
Add `completed_by_worker_shutdown` bool field to `PollWorkflowTaskQueueResponse`, `PollActivityTaskQueueResponse`, and `PollNexusTaskQueueResponse`.

[Server PR](https://github.com/temporalio/temporal/pull/9551)

## Why?
When the server completes a poll because the worker was shut down via `ShutdownWorker`, SDKs currently receive an empty response indistinguishable from a normal poll timeout. This gives SDKs an explicit signal to stop re-polling, and is useful for debugging.

## How did you test it?
- [x] built
- [ ] server-side implementation in separate PR

## Potential risks
None — additive proto field, fully backward compatible.