### PR TITLE
feat: add worker runtime info to heartbeat

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -18288,6 +18288,24 @@
       "default": "ROUTING_CONFIG_UPDATE_STATE_UNSPECIFIED",
       "description": "Indicates whether a change to the Routing Config has been\npropagated to all relevant Task Queues and their partitions.\n\n - ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS: Update to the RoutingConfig is currently in progress.\n - ROUTING_CONFIG_UPDATE_STATE_COMPLETED: Update to the RoutingConfig has completed successfully."
     },
+    "v1RuntimeInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Runtime name"
+        },
+        "version": {
+          "type": "string",
+          "title": "Runtime version"
+        },
+        "provider": {
+          "type": "string",
+          "title": "Name of a known provider"
+        }
+      },
+      "description": "Information about the language runtime executing the worker."
+    },
     "v1Schedule": {
       "type": "object",
       "properties": {
@@ -20106,6 +20124,10 @@
             "$ref": "#/definitions/v1StorageDriverInfo"
           },
           "description": "Storage drivers in use by this SDK."
+        },
+        "runtimeInfo": {
+          "$ref": "#/definitions/v1RuntimeInfo",
+          "description": "Information about the language runtime executing the worker."
         }
       },
       "description": "Worker info message, contains information about the worker and its current state.\nAll information is provided by the worker itself."
@@ -20207,6 +20229,10 @@
             "$ref": "#/definitions/v1StorageDriverInfo"
           },
           "description": "Storage drivers in use by this SDK."
+        },
+        "runtimeInfo": {
+          "$ref": "#/definitions/v1RuntimeInfo",
+          "description": "Information about the language runtime executing the worker."
         }
       },
       "description": "Limited worker information returned in the list response.\nWhen adding fields here, ensure that it is also added to WorkerInfo (as it carries the full worker information)."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -18301,7 +18301,7 @@
         },
         "provider": {
           "type": "string",
-          "title": "Name of a known provider"
+          "title": "Name of a known hosting provider"
         }
       },
       "description": "Information about the language runtime executing the worker."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15358,7 +15358,7 @@ components:
           description: Runtime version
         provider:
           type: string
-          description: Name of a known provider
+          description: Name of a known hosting provider
       description: Information about the language runtime executing the worker.
     Schedule:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15347,6 +15347,19 @@ components:
           description: |-
             Monotonically increasing value which is incremented on every mutation
              to any field of this message to achieve eventual consistency between task queues and their partitions.
+    RuntimeInfo:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Runtime name
+        version:
+          type: string
+          description: Runtime version
+        provider:
+          type: string
+          description: Name of a known provider
+      description: Information about the language runtime executing the worker.
     Schedule:
       type: object
       properties:
@@ -18546,6 +18559,10 @@ components:
           items:
             $ref: '#/components/schemas/StorageDriverInfo'
           description: Storage drivers in use by this SDK.
+        runtimeInfo:
+          allOf:
+            - $ref: '#/components/schemas/RuntimeInfo'
+          description: Information about the language runtime executing the worker.
       description: |-
         Worker info message, contains information about the worker and its current state.
          All information is provided by the worker itself.
@@ -18648,6 +18665,10 @@ components:
           items:
             $ref: '#/components/schemas/StorageDriverInfo'
           description: Storage drivers in use by this SDK.
+        runtimeInfo:
+          allOf:
+            - $ref: '#/components/schemas/RuntimeInfo'
+          description: Information about the language runtime executing the worker.
       description: |-
         Limited worker information returned in the list response.
          When adding fields here, ensure that it is also added to WorkerInfo (as it carries the full worker information).

--- a/temporal/api/worker/v1/message.proto
+++ b/temporal/api/worker/v1/message.proto
@@ -130,6 +130,9 @@ message WorkerHeartbeat {
 
   // Storage drivers in use by this SDK.
   repeated StorageDriverInfo drivers = 24;
+
+  // Information about the language runtime executing the worker.
+  RuntimeInfo runtime_info = 25;
 }
 
 // Detailed worker information.
@@ -180,6 +183,9 @@ message WorkerListInfo {
 
   // Storage drivers in use by this SDK.
   repeated StorageDriverInfo drivers = 13;
+
+  // Information about the language runtime executing the worker.
+  RuntimeInfo runtime_info = 14;
 }
 
 message PluginInfo {
@@ -192,6 +198,16 @@ message PluginInfo {
 message StorageDriverInfo {
   // The type of the driver, required.
   string type = 1;
+}
+
+// Information about the language runtime executing the worker.
+message RuntimeInfo {
+  // Runtime name
+  string name = 1;
+  // Runtime version
+  string version = 2;
+  // Name of a known provider
+  string provider = 3;
 }
 
 // A command sent from the server to a worker.

--- a/temporal/api/worker/v1/message.proto
+++ b/temporal/api/worker/v1/message.proto
@@ -206,7 +206,7 @@ message RuntimeInfo {
   string name = 1;
   // Runtime version
   string version = 2;
-  // Name of a known provider
+  // Name of a known hosting provider
   string provider = 3;
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Add worker runtime information to worker heartbeat. Will be used to track both runtime version (Node 20 vs 24) and different runtimes (Node vs Bun).

**Why?**
Record which runtimes are being used in the SDK. Needed to complete https://github.com/temporalio/sdk-typescript/issues/1964


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
No


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
