### PR TITLE
Fix first_execution_run_id comments on Cancel and Terminate RPCs

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -9156,6 +9156,19 @@
       },
       "description": "Target a worker polling on a Nexus task queue in a specific namespace."
     },
+    "ExecuteMultiOperationRequestOperation": {
+      "type": "object",
+      "properties": {
+        "startWorkflow": {
+          "$ref": "#/definitions/v1StartWorkflowExecutionRequest",
+          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid\n- setting `workflow_start_delay` is invalid"
+        },
+        "updateWorkflow": {
+          "$ref": "#/definitions/v1UpdateWorkflowExecutionRequest",
+          "title": "Additional restrictions:\n- setting `first_execution_run_id` is invalid\n- setting `workflow_execution.run_id` is invalid"
+        }
+      }
+    },
     "LinkBatchJob": {
       "type": "object",
       "properties": {
@@ -9319,7 +9332,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionSignaled event."
         }
@@ -9340,6 +9353,42 @@
       },
       "description": "UpdateWorkflowOptions represents updating workflow execution options after a workflow reset.\nKeep the parameters in sync with temporal.api.workflowservice.v1.UpdateWorkflowExecutionOptionsRequest."
     },
+    "StartOperationResponseAsync": {
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "Deprecated. Renamed to operation_token."
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apinexusv1Link"
+          }
+        },
+        "operationToken": {
+          "type": "string"
+        }
+      },
+      "description": "The operation will complete asynchronously.\nThe returned ID can be used to reference this operation."
+    },
+    "StartOperationResponseSync": {
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/v1Payload"
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apinexusv1Link"
+          }
+        }
+      },
+      "description": "An operation completed successfully."
+    },
     "UpdateTaskQueueConfigRequestRateLimitUpdate": {
       "type": "object",
       "properties": {
@@ -9352,6 +9401,119 @@
           "description": "Reason for why the rate limit was set."
         }
       }
+    },
+    "UpdateWorkerBuildIdCompatibilityRequestAddNewCompatibleVersion": {
+      "type": "object",
+      "properties": {
+        "newBuildId": {
+          "type": "string",
+          "description": "A new id to be added to an existing compatible set."
+        },
+        "existingCompatibleBuildId": {
+          "type": "string",
+          "description": "A build id which must already exist in the version sets known by the task queue. The new\nid will be stored in the set containing this id, marking it as compatible with\nthe versions within."
+        },
+        "makeSetDefault": {
+          "type": "boolean",
+          "description": "When set, establishes the compatible set being targeted as the overall default for the\nqueue. If a different set was the current default, the targeted set will replace it as\nthe new default."
+        }
+      }
+    },
+    "UpdateWorkerBuildIdCompatibilityRequestMergeSets": {
+      "type": "object",
+      "properties": {
+        "primarySetBuildId": {
+          "type": "string",
+          "title": "A build ID in the set whose default will become the merged set default"
+        },
+        "secondarySetBuildId": {
+          "type": "string",
+          "title": "A build ID in the set which will be merged into the primary set"
+        }
+      }
+    },
+    "UpdateWorkerVersioningRulesRequestAddCompatibleBuildIdRedirectRule": {
+      "type": "object",
+      "properties": {
+        "rule": {
+          "$ref": "#/definitions/v1CompatibleBuildIdRedirectRule"
+        }
+      },
+      "description": "Adds the rule to the list of redirect rules for this Task Queue. There\ncan be at most one redirect rule for each distinct Source Build ID."
+    },
+    "UpdateWorkerVersioningRulesRequestCommitBuildId": {
+      "type": "object",
+      "properties": {
+        "targetBuildId": {
+          "type": "string"
+        },
+        "force": {
+          "type": "boolean",
+          "description": "To prevent committing invalid Build IDs, we reject the request if no\npollers has been seen recently for this Build ID. Use the `force`\noption to disable this validation."
+        }
+      },
+      "description": "This command is intended to be used to complete the rollout of a Build\nID and cleanup unnecessary rules possibly created during a gradual\nrollout. Specifically, this command will make the following changes\natomically:\n 1. Adds an assignment rule (with full ramp) for the target Build ID at\n    the end of the list.\n 2. Removes all previously added assignment rules to the given target\n    Build ID (if any).\n 3. Removes any fully-ramped assignment rule for other Build IDs."
+    },
+    "UpdateWorkerVersioningRulesRequestDeleteBuildIdAssignmentRule": {
+      "type": "object",
+      "properties": {
+        "ruleIndex": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "force": {
+          "type": "boolean",
+          "title": "By default presence of one unconditional rule is enforced, otherwise\nthe delete operation will be rejected. Set `force` to true to\nbypass this validation. An unconditional assignment rule:\n  - Has no hint filter\n  - Has no ramp"
+        }
+      }
+    },
+    "UpdateWorkerVersioningRulesRequestDeleteCompatibleBuildIdRedirectRule": {
+      "type": "object",
+      "properties": {
+        "sourceBuildId": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateWorkerVersioningRulesRequestInsertBuildIdAssignmentRule": {
+      "type": "object",
+      "properties": {
+        "ruleIndex": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Use this option to insert the rule in a particular index. By\ndefault, the new rule is inserted at the beginning of the list\n(index 0). If the given index is too larger the rule will be\ninserted at the end of the list."
+        },
+        "rule": {
+          "$ref": "#/definitions/v1BuildIdAssignmentRule"
+        }
+      },
+      "description": "Inserts the rule to the list of assignment rules for this Task Queue.\nThe rules are evaluated in order, starting from index 0. The first\napplicable rule will be applied and the rest will be ignored."
+    },
+    "UpdateWorkerVersioningRulesRequestReplaceBuildIdAssignmentRule": {
+      "type": "object",
+      "properties": {
+        "ruleIndex": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "rule": {
+          "$ref": "#/definitions/v1BuildIdAssignmentRule"
+        },
+        "force": {
+          "type": "boolean",
+          "title": "By default presence of one unconditional rule is enforced, otherwise\nthe replace operation will be rejected. Set `force` to true to\nbypass this validation. An unconditional assignment rule:\n  - Has no hint filter\n  - Has no ramp"
+        }
+      },
+      "description": "Replaces the assignment rule at a given index."
+    },
+    "UpdateWorkerVersioningRulesRequestReplaceCompatibleBuildIdRedirectRule": {
+      "type": "object",
+      "properties": {
+        "rule": {
+          "$ref": "#/definitions/v1CompatibleBuildIdRedirectRule"
+        }
+      },
+      "description": "Replaces the routing rule with the given source Build ID."
     },
     "VersioningOverridePinnedOverride": {
       "type": "object",
@@ -9830,7 +9992,7 @@
         },
         "firstExecutionRunId": {
           "type": "string",
-          "description": "If set, this call will error if the most recent (if no run id is set on\n`workflow_execution`), or specified (if it is) workflow execution is not part of the same\nexecution chain as this id."
+          "description": "If set, the run id on `workflow_execution` is ignored and the most recent\nworkflow execution for the given workflow id is resolved. This call will\nthen error if that execution is not part of the same execution chain as\nthis id."
         },
         "reason": {
           "type": "string",
@@ -9840,7 +10002,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCommonV1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionCanceled event."
         }
@@ -9898,7 +10060,8 @@
               "type": "string"
             }
           },
-          "description": "The workflow to reset. If this contains a run ID then the workflow will be reset back to the\nprovided event ID in that run. Otherwise it will be reset to the provided event ID in the\ncurrent run. In all cases the current run will be terminated and a new run started."
+          "description": "The workflow to reset. If this contains a run ID then the workflow will be reset back to the\nprovided event ID in that run. Otherwise it will be reset to the provided event ID in the\ncurrent run. In all cases the current run will be terminated and a new run started.",
+          "title": "The workflow to reset. If this contains a run ID then the workflow will be reset back to the\nprovided event ID in that run. Otherwise it will be reset to the provided event ID in the\ncurrent run. In all cases the current run will be terminated and a new run started."
         },
         "reason": {
           "type": "string"
@@ -10060,7 +10223,7 @@
           "title": "The task token as received in `PollActivityTaskQueueResponse`"
         },
         "failure": {
-          "$ref": "#/definitions/apiFailureV1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "title": "Detailed failure information"
         },
         "identity": {
@@ -10097,7 +10260,7 @@
           "description": "For a workflow activity - the run ID of the workflow which scheduled this activity.\nFor a standalone activity - the run ID of the activity."
         },
         "failure": {
-          "$ref": "#/definitions/apiFailureV1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "title": "Detailed failure information"
         },
         "identity": {
@@ -10307,7 +10470,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCommonV1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionStarted and WorkflowExecutionSignaled events."
         },
@@ -10361,7 +10524,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCommonV1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionSignaled event."
         }
@@ -10553,7 +10716,7 @@
           "description": "Request to get the first workflow task inline in the response bypassing matching service and worker polling.\nIf set to `true` the caller is expected to have a worker available and capable of processing the task.\nThe returned task will be marked as started and is expected to be completed by the specified\n`workflow_task_timeout`."
         },
         "continuedFailure": {
-          "$ref": "#/definitions/apiFailureV1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "These values will be available as ContinuedFailure and LastCompletionResult in the\nWorkflowExecutionStarted event and through SDKs. The are currently only used by the\nserver itself (for the schedules feature) and are not intended to be exposed in\nStartWorkflowExecution."
         },
         "lastCompletionResult": {
@@ -10579,7 +10742,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCommonV1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links to be associated with the workflow."
         },
@@ -10664,13 +10827,13 @@
         },
         "firstExecutionRunId": {
           "type": "string",
-          "description": "If set, this call will error if the most recent (if no run id is set on\n`workflow_execution`), or specified (if it is) workflow execution is not part of the same\nexecution chain as this id."
+          "description": "If set, the run id on `workflow_execution` is ignored and the most recent\nworkflow execution for the given workflow id is resolved. This call will\nthen error if that execution is not part of the same execution chain as\nthis id."
         },
         "links": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/apiCommonV1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionTerminated event."
         }
@@ -11020,7 +11183,8 @@
               }
             }
           },
-          "description": "The request information that will be delivered all the way down to the\nWorkflow Execution."
+          "description": "The request information that will be delivered all the way down to the\nWorkflow Execution.",
+          "title": "The request information that will be delivered all the way down to the\nWorkflow Execution."
         }
       }
     },
@@ -11080,6 +11244,163 @@
         }
       },
       "description": "Used to validate the compute config without attaching it to a Worker Deployment Version."
+    },
+    "apicommonv1Link": {
+      "type": "object",
+      "properties": {
+        "workflowEvent": {
+          "$ref": "#/definitions/LinkWorkflowEvent"
+        },
+        "batchJob": {
+          "$ref": "#/definitions/LinkBatchJob"
+        }
+      },
+      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
+    },
+    "apifailurev1Failure": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "encodedAttributes": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
+        },
+        "cause": {
+          "$ref": "#/definitions/apifailurev1Failure"
+        },
+        "applicationFailureInfo": {
+          "$ref": "#/definitions/v1ApplicationFailureInfo"
+        },
+        "timeoutFailureInfo": {
+          "$ref": "#/definitions/v1TimeoutFailureInfo"
+        },
+        "canceledFailureInfo": {
+          "$ref": "#/definitions/v1CanceledFailureInfo"
+        },
+        "terminatedFailureInfo": {
+          "$ref": "#/definitions/v1TerminatedFailureInfo"
+        },
+        "serverFailureInfo": {
+          "$ref": "#/definitions/v1ServerFailureInfo"
+        },
+        "resetWorkflowFailureInfo": {
+          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
+        },
+        "activityFailureInfo": {
+          "$ref": "#/definitions/v1ActivityFailureInfo"
+        },
+        "childWorkflowExecutionFailureInfo": {
+          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
+        },
+        "nexusOperationExecutionFailureInfo": {
+          "$ref": "#/definitions/v1NexusOperationFailureInfo"
+        },
+        "nexusHandlerFailureInfo": {
+          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
+        }
+      }
+    },
+    "apinexusv1Failure": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "details": {
+          "type": "string",
+          "format": "byte",
+          "description": "UTF-8 encoded JSON serializable details."
+        },
+        "cause": {
+          "$ref": "#/definitions/apinexusv1Failure"
+        }
+      },
+      "title": "A general purpose failure message.\nSee: https://github.com/nexus-rpc/api/blob/main/SPEC.md#failure"
+    },
+    "apinexusv1Link": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "See https://github.com/nexus-rpc/api/blob/main/SPEC.md#links."
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "apinexusv1Request": {
+      "type": "object",
+      "properties": {
+        "header": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Headers extracted from the original request in the Temporal frontend.\nWhen using Nexus over HTTP, this includes the request's HTTP headers ignoring multiple values."
+        },
+        "scheduledTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp when the request was scheduled in the frontend."
+        },
+        "capabilities": {
+          "$ref": "#/definitions/v1RequestCapabilities"
+        },
+        "startOperation": {
+          "$ref": "#/definitions/v1StartOperationRequest"
+        },
+        "cancelOperation": {
+          "$ref": "#/definitions/v1CancelOperationRequest"
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "The endpoint this request was addressed to before forwarding to the worker.\nSupported from server version 1.30.0."
+        }
+      },
+      "description": "A Nexus request."
+    },
+    "apinexusv1Response": {
+      "type": "object",
+      "properties": {
+        "startOperation": {
+          "$ref": "#/definitions/v1StartOperationResponse"
+        },
+        "cancelOperation": {
+          "$ref": "#/definitions/v1CancelOperationResponse"
+        }
+      },
+      "description": "A response indicating that the handler has successfully processed a request."
+    },
+    "apiupdatev1Request": {
+      "type": "object",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/v1Meta"
+        },
+        "input": {
+          "$ref": "#/definitions/v1Input"
+        }
+      },
+      "description": "The client request that triggers a Workflow Update."
     },
     "protobufAny": {
       "type": "object",
@@ -11195,7 +11516,7 @@
           "description": "Time when the activity transitioned to a closed state."
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details from the last failed attempt."
         },
         "lastWorkerIdentity": {
@@ -11312,7 +11633,7 @@
           "description": "The result if the activity completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "The failure if the activity completed unsuccessfully."
         }
       },
@@ -11502,7 +11823,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "title": "Failure details"
         },
         "scheduledEventId": {
@@ -11604,7 +11925,7 @@
           "title": "Starting at 1, the number of times this task has been attempted"
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Will be set to the most recent failure details, if this task has previously failed and then\nbeen retried."
         },
         "workerVersion": {
@@ -11622,7 +11943,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "If this activity had failed, was retried, and then timed out, that failure is stored as the\n`cause` in here."
         },
         "scheduledEventId": {
@@ -11648,6 +11969,12 @@
         }
       },
       "title": "Represents the identifier used by a activity author to define the activity. Typically, the\nname of a function. This is sometimes referred to as the activity's \"name\""
+    },
+    "v1AddOrUpdateRemoteClusterResponse": {
+      "type": "object"
+    },
+    "v1AddSearchAttributesResponse": {
+      "type": "object"
     },
     "v1Alert": {
       "type": "object",
@@ -12082,7 +12409,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links associated with the callback. It can be used to link to underlying resources of the\ncallback."
         }
@@ -12119,7 +12446,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -12156,6 +12483,49 @@
         "CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND"
       ],
       "default": "CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED"
+    },
+    "v1CancelOperationRequest": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Type of operation to cancel."
+        },
+        "operationId": {
+          "type": "string",
+          "description": "Operation ID as originally generated by a Handler.\n\nDeprecated. Renamed to operation_token."
+        },
+        "operationToken": {
+          "type": "string",
+          "description": "Operation token as originally generated by a Handler."
+        }
+      },
+      "description": "A request to cancel an operation."
+    },
+    "v1CancelOperationResponse": {
+      "type": "object",
+      "description": "Response variant for CancelOperationRequest."
+    },
+    "v1CancelTimerCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "timerId": {
+          "type": "string",
+          "title": "The same timer id from the start timer command"
+        }
+      }
+    },
+    "v1CancelWorkflowExecutionCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "details": {
+          "$ref": "#/definitions/v1Payloads"
+        }
+      }
     },
     "v1CanceledFailureInfo": {
       "type": "object",
@@ -12231,7 +12601,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apifailurev1Failure"
         },
         "namespace": {
           "type": "string",
@@ -12371,6 +12741,45 @@
         }
       }
     },
+    "v1ClusterMetadata": {
+      "type": "object",
+      "properties": {
+        "clusterName": {
+          "type": "string",
+          "description": "Name of the cluster name."
+        },
+        "clusterId": {
+          "type": "string",
+          "description": "Id of the cluster."
+        },
+        "address": {
+          "type": "string",
+          "description": "gRPC address."
+        },
+        "httpAddress": {
+          "type": "string",
+          "description": "HTTP address, if one exists."
+        },
+        "initialFailoverVersion": {
+          "type": "string",
+          "format": "int64",
+          "description": "A unique failover version across all connected clusters."
+        },
+        "historyShardCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "History service shard number."
+        },
+        "isConnectionEnabled": {
+          "type": "boolean",
+          "description": "A flag to indicate if a connection is active."
+        },
+        "isReplicationEnabled": {
+          "type": "boolean",
+          "description": "A flag to indicate if replication is enabled."
+        }
+      }
+    },
     "v1ClusterReplicationConfig": {
       "type": "object",
       "properties": {
@@ -12378,6 +12787,95 @@
           "type": "string"
         }
       }
+    },
+    "v1Command": {
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "$ref": "#/definitions/v1CommandType"
+        },
+        "userMetadata": {
+          "$ref": "#/definitions/v1UserMetadata",
+          "description": "Metadata on the command. This is sometimes carried over to the history event if one is\ncreated as a result of the command. Most commands won't have this information, and how this\ninformation is used is dependent upon the interface that reads it.\n\nCurrent well-known uses:\n * start_child_workflow_execution_command_attributes - populates\n   temporal.api.workflow.v1.WorkflowExecutionInfo.user_metadata where the summary and details\n   are used by user interfaces to show fixed as-of-start workflow summary and details.\n * start_timer_command_attributes - populates temporal.api.history.v1.HistoryEvent for timer\n   started where the summary is used to identify the timer."
+        },
+        "scheduleActivityTaskCommandAttributes": {
+          "$ref": "#/definitions/v1ScheduleActivityTaskCommandAttributes"
+        },
+        "startTimerCommandAttributes": {
+          "$ref": "#/definitions/v1StartTimerCommandAttributes"
+        },
+        "completeWorkflowExecutionCommandAttributes": {
+          "$ref": "#/definitions/v1CompleteWorkflowExecutionCommandAttributes"
+        },
+        "failWorkflowExecutionCommandAttributes": {
+          "$ref": "#/definitions/v1FailWorkflowExecutionCommandAttributes"
+        },
+        "requestCancelActivityTaskCommandAttributes": {
+          "$ref": "#/definitions/v1RequestCancelActivityTaskCommandAttributes"
+        },
+        "cancelTimerCommandAttributes": {
+          "$ref": "#/definitions/v1CancelTimerCommandAttributes"
+        },
+        "cancelWorkflowExecutionCommandAttributes": {
+          "$ref": "#/definitions/v1CancelWorkflowExecutionCommandAttributes"
+        },
+        "requestCancelExternalWorkflowExecutionCommandAttributes": {
+          "$ref": "#/definitions/v1RequestCancelExternalWorkflowExecutionCommandAttributes"
+        },
+        "recordMarkerCommandAttributes": {
+          "$ref": "#/definitions/v1RecordMarkerCommandAttributes"
+        },
+        "continueAsNewWorkflowExecutionCommandAttributes": {
+          "$ref": "#/definitions/v1ContinueAsNewWorkflowExecutionCommandAttributes"
+        },
+        "startChildWorkflowExecutionCommandAttributes": {
+          "$ref": "#/definitions/v1StartChildWorkflowExecutionCommandAttributes"
+        },
+        "signalExternalWorkflowExecutionCommandAttributes": {
+          "$ref": "#/definitions/v1SignalExternalWorkflowExecutionCommandAttributes"
+        },
+        "upsertWorkflowSearchAttributesCommandAttributes": {
+          "$ref": "#/definitions/v1UpsertWorkflowSearchAttributesCommandAttributes"
+        },
+        "protocolMessageCommandAttributes": {
+          "$ref": "#/definitions/v1ProtocolMessageCommandAttributes"
+        },
+        "modifyWorkflowPropertiesCommandAttributes": {
+          "$ref": "#/definitions/v1ModifyWorkflowPropertiesCommandAttributes",
+          "title": "16 is available for use - it was used as part of a prototype that never made it into a release"
+        },
+        "scheduleNexusOperationCommandAttributes": {
+          "$ref": "#/definitions/v1ScheduleNexusOperationCommandAttributes"
+        },
+        "requestCancelNexusOperationCommandAttributes": {
+          "$ref": "#/definitions/v1RequestCancelNexusOperationCommandAttributes"
+        }
+      }
+    },
+    "v1CommandType": {
+      "type": "string",
+      "enum": [
+        "COMMAND_TYPE_UNSPECIFIED",
+        "COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK",
+        "COMMAND_TYPE_REQUEST_CANCEL_ACTIVITY_TASK",
+        "COMMAND_TYPE_START_TIMER",
+        "COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION",
+        "COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION",
+        "COMMAND_TYPE_CANCEL_TIMER",
+        "COMMAND_TYPE_CANCEL_WORKFLOW_EXECUTION",
+        "COMMAND_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION",
+        "COMMAND_TYPE_RECORD_MARKER",
+        "COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION",
+        "COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION",
+        "COMMAND_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION",
+        "COMMAND_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+        "COMMAND_TYPE_PROTOCOL_MESSAGE",
+        "COMMAND_TYPE_MODIFY_WORKFLOW_PROPERTIES",
+        "COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION",
+        "COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION"
+      ],
+      "default": "COMMAND_TYPE_UNSPECIFIED",
+      "description": "Whenever this list of command types is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering."
     },
     "v1CompatibleBuildIdRedirectRule": {
       "type": "object",
@@ -12404,6 +12902,14 @@
         }
       },
       "description": "Used by the worker versioning APIs, represents an unordered set of one or more versions which are\nconsidered to be compatible with each other. Currently the versions are always worker build IDs."
+    },
+    "v1CompleteWorkflowExecutionCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "$ref": "#/definitions/v1Payloads"
+        }
+      }
     },
     "v1ComputeConfig": {
       "type": "object",
@@ -12519,6 +13025,68 @@
       ],
       "default": "CONTINUE_AS_NEW_VERSIONING_BEHAVIOR_UNSPECIFIED",
       "description": "Experimental. Defines the versioning behavior to be used by the first task of a new workflow run in a continue-as-new chain.\n\n - CONTINUE_AS_NEW_VERSIONING_BEHAVIOR_AUTO_UPGRADE: Start the new run with AutoUpgrade behavior. Use the Target Version of the workflow's task queue at\nstart-time, as AutoUpgrade workflows do. After the first workflow task completes, use whatever\nVersioning Behavior the workflow is annotated with in the workflow code.\n\nNote that if the previous workflow had a Pinned override, that override will be inherited by the\nnew workflow run regardless of the ContinueAsNewVersioningBehavior specified in the continue-as-new\ncommand. If a Pinned override is inherited by the new run, and the new run starts with AutoUpgrade\nbehavior, the base version of the new run will be the Target Version as described above, but the\neffective version will be whatever is specified by the Versioning Override until the override is removed."
+    },
+    "v1ContinueAsNewWorkflowExecutionCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "workflowType": {
+          "$ref": "#/definitions/v1WorkflowType"
+        },
+        "taskQueue": {
+          "$ref": "#/definitions/v1TaskQueue"
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payloads"
+        },
+        "workflowRunTimeout": {
+          "type": "string",
+          "description": "Timeout of a single workflow run."
+        },
+        "workflowTaskTimeout": {
+          "type": "string",
+          "description": "Timeout of a single workflow task."
+        },
+        "backoffStartInterval": {
+          "type": "string",
+          "description": "How long the workflow start will be delayed - not really a \"backoff\" in the traditional sense."
+        },
+        "retryPolicy": {
+          "$ref": "#/definitions/v1RetryPolicy"
+        },
+        "initiator": {
+          "$ref": "#/definitions/v1ContinueAsNewInitiator",
+          "title": "Should be removed"
+        },
+        "failure": {
+          "$ref": "#/definitions/apifailurev1Failure",
+          "title": "Should be removed"
+        },
+        "lastCompletionResult": {
+          "$ref": "#/definitions/v1Payloads",
+          "title": "Should be removed"
+        },
+        "cronSchedule": {
+          "type": "string",
+          "description": "Should be removed. Not necessarily unused but unclear and not exposed by SDKs."
+        },
+        "header": {
+          "$ref": "#/definitions/v1Header"
+        },
+        "memo": {
+          "$ref": "#/definitions/v1Memo"
+        },
+        "searchAttributes": {
+          "$ref": "#/definitions/v1SearchAttributes"
+        },
+        "inheritBuildId": {
+          "type": "boolean",
+          "description": "If this is set, the new execution inherits the Build ID of the current execution. Otherwise,\nthe assignment rules will be used to independently assign a Build ID to the new execution.\nDeprecated. Only considered for versioning v0.2."
+        },
+        "initialVersioningBehavior": {
+          "$ref": "#/definitions/v1ContinueAsNewVersioningBehavior",
+          "description": "Experimental. Optionally decide the versioning behavior that the first task of the new run should use.\nFor example, choose to AutoUpgrade on continue-as-new instead of inheriting the pinned version\nof the previous run."
+        }
+      }
     },
     "v1CountActivityExecutionsResponse": {
       "type": "object",
@@ -12696,6 +13264,18 @@
       },
       "description": "Wrapper for a target deployment version that the SDK declined to upgrade to.\nSee declined_target_version_upgrade on WorkflowExecutionStartedEventAttributes."
     },
+    "v1DeleteActivityExecutionResponse": {
+      "type": "object"
+    },
+    "v1DeleteNamespaceResponse": {
+      "type": "object",
+      "properties": {
+        "deletedNamespace": {
+          "type": "string",
+          "description": "Temporary namespace name that is used during reclaim resources step."
+        }
+      }
+    },
     "v1DeleteNexusEndpointResponse": {
       "type": "object"
     },
@@ -12706,6 +13286,9 @@
       "type": "object"
     },
     "v1DeleteWorkerDeploymentVersionResponse": {
+      "type": "object"
+    },
+    "v1DeleteWorkflowExecutionResponse": {
       "type": "object"
     },
     "v1DeleteWorkflowRuleResponse": {
@@ -12807,6 +13390,10 @@
         }
       },
       "description": "Holds information about ongoing transition of a workflow execution from one worker\ndeployment version to another.\nExperimental. Might change in the future."
+    },
+    "v1DeprecateNamespaceResponse": {
+      "type": "object",
+      "description": "Deprecated."
     },
     "v1DescribeActivityExecutionResponse": {
       "type": "object",
@@ -13233,6 +13820,30 @@
       "description": "- EVENT_TYPE_UNSPECIFIED: Place holder and should never appear in a Workflow execution history\n - EVENT_TYPE_WORKFLOW_EXECUTION_STARTED: Workflow execution has been triggered/started\nIt contains Workflow execution inputs, as well as Workflow timeout configurations\n - EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED: Workflow execution has successfully completed and contains Workflow execution results\n - EVENT_TYPE_WORKFLOW_EXECUTION_FAILED: Workflow execution has unsuccessfully completed and contains the Workflow execution error\n - EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT: Workflow execution has timed out by the Temporal Server\nUsually due to the Workflow having not been completed within timeout settings\n - EVENT_TYPE_WORKFLOW_TASK_SCHEDULED: Workflow Task has been scheduled and the SDK client should now be able to process any new history events\n - EVENT_TYPE_WORKFLOW_TASK_STARTED: Workflow Task has started and the SDK client has picked up the Workflow Task and is processing new history events\n - EVENT_TYPE_WORKFLOW_TASK_COMPLETED: Workflow Task has completed\nThe SDK client picked up the Workflow Task and processed new history events\nSDK client may or may not ask the Temporal Server to do additional work, such as:\nEVENT_TYPE_ACTIVITY_TASK_SCHEDULED\nEVENT_TYPE_TIMER_STARTED\nEVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES\nEVENT_TYPE_MARKER_RECORDED\nEVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED\nEVENT_TYPE_WORKFLOW_EXECUTION_FAILED\nEVENT_TYPE_WORKFLOW_EXECUTION_CANCELED\nEVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW\n - EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT: Workflow Task encountered a timeout\nEither an SDK client with a local cache was not available at the time, or it took too long for the SDK client to process the task\n - EVENT_TYPE_WORKFLOW_TASK_FAILED: Workflow Task encountered a failure\nUsually this means that the Workflow was non-deterministic\nHowever, the Workflow reset functionality also uses this event\n - EVENT_TYPE_ACTIVITY_TASK_SCHEDULED: Activity Task was scheduled\nThe SDK client should pick up this activity task and execute\nThis event type contains activity inputs, as well as activity timeout configurations\n - EVENT_TYPE_ACTIVITY_TASK_STARTED: Activity Task has started executing\nThe SDK client has picked up the Activity Task and is processing the Activity invocation\n - EVENT_TYPE_ACTIVITY_TASK_COMPLETED: Activity Task has finished successfully\nThe SDK client has picked up and successfully completed the Activity Task\nThis event type contains Activity execution results\n - EVENT_TYPE_ACTIVITY_TASK_FAILED: Activity Task has finished unsuccessfully\nThe SDK picked up the Activity Task but unsuccessfully completed it\nThis event type contains Activity execution errors\n - EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT: Activity has timed out according to the Temporal Server\nActivity did not complete within the timeout settings\n - EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED: A request to cancel the Activity has occurred\nThe SDK client will be able to confirm cancellation of an Activity during an Activity heartbeat\n - EVENT_TYPE_ACTIVITY_TASK_CANCELED: Activity has been cancelled\n - EVENT_TYPE_TIMER_STARTED: A timer has started\n - EVENT_TYPE_TIMER_FIRED: A timer has fired\n - EVENT_TYPE_TIMER_CANCELED: A time has been cancelled\n - EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED: A request has been made to cancel the Workflow execution\n - EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED: SDK client has confirmed the cancellation request and the Workflow execution has been cancelled\n - EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED: Workflow has requested that the Temporal Server try to cancel another Workflow\n - EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED: Temporal Server could not cancel the targeted Workflow\nThis is usually because the target Workflow could not be found\n - EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED: Temporal Server has successfully requested the cancellation of the target Workflow\n - EVENT_TYPE_MARKER_RECORDED: A marker has been recorded.\nThis event type is transparent to the Temporal Server\nThe Server will only store it and will not try to understand it.\n - EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED: Workflow has received a Signal event\nThe event type contains the Signal name, as well as a Signal payload\n - EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED: Workflow execution has been forcefully terminated\nThis is usually because the terminate Workflow API was called\n - EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW: Workflow has successfully completed and a new Workflow has been started within the same transaction\nContains last Workflow execution results as well as new Workflow execution inputs\n - EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED: Temporal Server will try to start a child Workflow\n - EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED: Child Workflow execution cannot be started/triggered\nUsually due to a child Workflow ID collision\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED: Child Workflow execution has successfully started/triggered\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED: Child Workflow execution has successfully completed\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED: Child Workflow execution has unsuccessfully completed\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED: Child Workflow execution has been cancelled\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT: Child Workflow execution has timed out by the Temporal Server\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED: Child Workflow execution has been terminated\n - EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED: Temporal Server will try to Signal the targeted Workflow\nContains the Signal name, as well as a Signal payload\n - EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED: Temporal Server cannot Signal the targeted Workflow\nUsually because the Workflow could not be found\n - EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED: Temporal Server has successfully Signaled the targeted Workflow\n - EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES: Workflow search attributes should be updated and synchronized with the visibility store\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED: An update was admitted. Note that not all admitted updates result in this\nevent. See UpdateAdmittedEventOrigin for situations in which this event\nis created.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED: An update was accepted (i.e. passed validation, perhaps because no validator was defined)\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED: This event is never written to history.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED: An update completed\n - EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY: Some property or properties of the workflow as a whole have changed by non-workflow code.\nThe distinction of external vs. command-based modification is important so the SDK can\nmaintain determinism when using the command-based approach.\n - EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY: Some property or properties of an already-scheduled activity have changed by non-workflow code.\nThe distinction of external vs. command-based modification is important so the SDK can\nmaintain determinism when using the command-based approach.\n - EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED: Workflow properties modified by user workflow code\n - EVENT_TYPE_NEXUS_OPERATION_SCHEDULED: A Nexus operation was scheduled using a ScheduleNexusOperation command.\n - EVENT_TYPE_NEXUS_OPERATION_STARTED: An asynchronous Nexus operation was started by a Nexus handler.\n - EVENT_TYPE_NEXUS_OPERATION_COMPLETED: A Nexus operation completed successfully.\n - EVENT_TYPE_NEXUS_OPERATION_FAILED: A Nexus operation failed.\n - EVENT_TYPE_NEXUS_OPERATION_CANCELED: A Nexus operation completed as canceled.\n - EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT: A Nexus operation timed out.\n - EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED: A Nexus operation was requested to be canceled using a RequestCancelNexusOperation command.\n - EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED: Workflow execution options updated by user.\n - EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED: A cancellation request for a Nexus operation was successfully delivered to the Nexus handler.\n - EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED: A cancellation request for a Nexus operation resulted in an error.\n - EVENT_TYPE_WORKFLOW_EXECUTION_PAUSED: An event that indicates that the workflow execution has been paused.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UNPAUSED: An event that indicates that the previously paused workflow execution has been unpaused.\n - EVENT_TYPE_WORKFLOW_EXECUTION_TIME_SKIPPING_TRANSITIONED: An event that indicates time skipping advanced time or was disabled automatically after a bound was reached.",
       "title": "Whenever this list of events is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering"
     },
+    "v1ExecuteMultiOperationResponse": {
+      "type": "object",
+      "properties": {
+        "responses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ExecuteMultiOperationResponseResponse"
+          }
+        }
+      },
+      "description": "IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination (\"Update-with-Start\") when both\n  1. the workflow update for the requested update ID has already completed, and\n  2. the workflow for the requested workflow ID has already been closed,\nthen you'll receive\n  - an update response containing the update's outcome, and\n  - a start response with a `status` field that reflects the workflow's current state."
+    },
+    "v1ExecuteMultiOperationResponseResponse": {
+      "type": "object",
+      "properties": {
+        "startWorkflow": {
+          "$ref": "#/definitions/v1StartWorkflowExecutionResponse"
+        },
+        "updateWorkflow": {
+          "$ref": "#/definitions/v1UpdateWorkflowExecutionResponse"
+        }
+      }
+    },
     "v1ExternalWorkflowExecutionCancelRequestedEventAttributes": {
       "type": "object",
       "properties": {
@@ -13277,6 +13888,14 @@
         }
       }
     },
+    "v1FailWorkflowExecutionCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "failure": {
+          "$ref": "#/definitions/apifailurev1Failure"
+        }
+      }
+    },
     "v1FailoverStatus": {
       "type": "object",
       "properties": {
@@ -13291,58 +13910,6 @@
         }
       },
       "title": "Represents a historical replication status of a Namespace"
-    },
-    "v1Failure": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string",
-          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
-        },
-        "stackTrace": {
-          "type": "string"
-        },
-        "encodedAttributes": {
-          "$ref": "#/definitions/v1Payload",
-          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
-        },
-        "cause": {
-          "$ref": "#/definitions/v1Failure"
-        },
-        "applicationFailureInfo": {
-          "$ref": "#/definitions/v1ApplicationFailureInfo"
-        },
-        "timeoutFailureInfo": {
-          "$ref": "#/definitions/v1TimeoutFailureInfo"
-        },
-        "canceledFailureInfo": {
-          "$ref": "#/definitions/v1CanceledFailureInfo"
-        },
-        "terminatedFailureInfo": {
-          "$ref": "#/definitions/v1TerminatedFailureInfo"
-        },
-        "serverFailureInfo": {
-          "$ref": "#/definitions/v1ServerFailureInfo"
-        },
-        "resetWorkflowFailureInfo": {
-          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
-        },
-        "activityFailureInfo": {
-          "$ref": "#/definitions/v1ActivityFailureInfo"
-        },
-        "childWorkflowExecutionFailureInfo": {
-          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
-        },
-        "nexusOperationExecutionFailureInfo": {
-          "$ref": "#/definitions/v1NexusOperationFailureInfo"
-        },
-        "nexusHandlerFailureInfo": {
-          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
-        }
-      }
     },
     "v1FetchWorkerConfigResponse": {
       "type": "object",
@@ -13427,6 +13994,17 @@
       "properties": {
         "endpoint": {
           "$ref": "#/definitions/v1Endpoint"
+        }
+      }
+    },
+    "v1GetSearchAttributesResponse": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1IndexedValueType"
+          }
         }
       }
     },
@@ -13587,6 +14165,22 @@
         }
       }
     },
+    "v1HandlerError": {
+      "type": "object",
+      "properties": {
+        "errorType": {
+          "type": "string",
+          "description": "See https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors."
+        },
+        "failure": {
+          "$ref": "#/definitions/apinexusv1Failure"
+        },
+        "retryBehavior": {
+          "$ref": "#/definitions/v1NexusHandlerErrorRetryBehavior",
+          "description": "Retry behavior, defaults to the retry behavior of the error type as defined in the spec."
+        }
+      }
+    },
     "v1Header": {
       "type": "object",
       "properties": {
@@ -13648,7 +14242,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apicommonv1Link"
           },
           "description": "Links associated with the event."
         },
@@ -13906,18 +14500,6 @@
       },
       "description": "IntervalSpec matches times that can be expressed as:\nepoch + n * interval + phase\nwhere n is an integer.\nphase defaults to zero if missing. interval is required.\nBoth interval and phase must be non-negative and are truncated to the nearest\nsecond before any calculations.\nFor example, an interval of 1 hour with phase of zero would match every hour,\non the hour. The same interval but a phase of 19 minutes would match every\nxx:19:00. An interval of 28 days with phase zero would match\n2022-02-17T00:00:00Z (among other times). The same interval with a phase of 3\ndays, 5 hours, and 23 minutes would match 2022-02-20T05:23:00Z instead."
     },
-    "v1Link": {
-      "type": "object",
-      "properties": {
-        "workflowEvent": {
-          "$ref": "#/definitions/LinkWorkflowEvent"
-        },
-        "batchJob": {
-          "$ref": "#/definitions/LinkBatchJob"
-        }
-      },
-      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
-    },
     "v1ListActivityExecutionsResponse": {
       "type": "object",
       "properties": {
@@ -13961,6 +14543,39 @@
             "$ref": "#/definitions/v1BatchOperationInfo"
           },
           "title": "BatchOperationInfo contains the basic info about batch operation"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "v1ListClosedWorkflowExecutionsResponse": {
+      "type": "object",
+      "properties": {
+        "executions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1WorkflowExecutionInfo"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "v1ListClustersResponse": {
+      "type": "object",
+      "properties": {
+        "clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ClusterMetadata"
+          },
+          "title": "List of all cluster information"
         },
         "nextPageToken": {
           "type": "string",
@@ -14018,6 +14633,22 @@
         }
       }
     },
+    "v1ListOpenWorkflowExecutionsResponse": {
+      "type": "object",
+      "properties": {
+        "executions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1WorkflowExecutionInfo"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
     "v1ListScheduleMatchingTimesResponse": {
       "type": "object",
       "properties": {
@@ -14069,6 +14700,25 @@
             "type": "string"
           },
           "description": "Mapping from the attribute name to the visibility storage native type."
+        }
+      }
+    },
+    "v1ListTaskQueuePartitionsResponse": {
+      "type": "object",
+      "properties": {
+        "activityTaskQueuePartitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TaskQueuePartitionMetadata"
+          }
+        },
+        "workflowTaskQueuePartitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TaskQueuePartitionMetadata"
+          }
         }
       }
     },
@@ -14170,7 +14820,7 @@
           "$ref": "#/definitions/v1Header"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Some uses of markers, like a local activity, could \"fail\". If they did that is recorded here."
         }
       }
@@ -14236,6 +14886,15 @@
         }
       },
       "title": "Metadata relevant for metering purposes"
+    },
+    "v1ModifyWorkflowPropertiesCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "upsertedMemo": {
+          "$ref": "#/definitions/v1Memo",
+          "description": "If set, update the workflow memo with the provided values. The values will be merged with\nthe existing memo. If the user wants to delete values, a default/empty Payload should be\nused as the value for the key being deleted."
+        }
+      }
     },
     "v1NamespaceConfig": {
       "type": "object",
@@ -14508,7 +15167,7 @@
           "description": "The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported\nwith."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "scheduledEventId": {
@@ -14542,7 +15201,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Cancellation details."
         },
         "requestId": {
@@ -14574,7 +15233,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -14631,7 +15290,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo."
         },
         "requestId": {
@@ -14758,7 +15417,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "requestId": {
@@ -14793,7 +15452,7 @@
           "$ref": "#/definitions/v1Payloads"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apifailurev1Failure"
         }
       },
       "description": "The outcome of a Workflow Update: success or failure."
@@ -14876,7 +15535,7 @@
           "format": "date-time"
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apifailurev1Failure"
         },
         "lastWorkerIdentity": {
           "type": "string"
@@ -15014,7 +15673,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -15117,6 +15776,130 @@
         },
         "outcome": {
           "$ref": "#/definitions/v1ActivityExecutionOutcome"
+        }
+      }
+    },
+    "v1PollActivityTaskQueueResponse": {
+      "type": "object",
+      "properties": {
+        "taskToken": {
+          "type": "string",
+          "format": "byte",
+          "title": "A unique identifier for this task"
+        },
+        "workflowNamespace": {
+          "type": "string",
+          "description": "The namespace of the activity. If this is a workflow activity then this is the namespace of\nthe workflow also. If this is a standalone activity then the name of this field is\nmisleading, but retained for compatibility with workflow activities."
+        },
+        "workflowType": {
+          "$ref": "#/definitions/v1WorkflowType",
+          "description": "Type of the requesting workflow (if this is a workflow activity)."
+        },
+        "workflowExecution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "title": "Execution info of the requesting workflow (if this is a workflow activity)"
+        },
+        "activityType": {
+          "$ref": "#/definitions/v1ActivityType"
+        },
+        "activityId": {
+          "type": "string",
+          "description": "The autogenerated or user specified identifier of this activity. Can be used to complete the\nactivity via `RespondActivityTaskCompletedById`. May be re-used as long as the last usage\nhas resolved, but unique IDs for every activity invocation is a good idea.\nNote that only a workflow activity ID may be autogenerated."
+        },
+        "header": {
+          "$ref": "#/definitions/v1Header",
+          "description": "Headers specified by the scheduling workflow. Commonly used to propagate contextual info\nfrom the workflow to its activities. For example, tracing contexts."
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payloads",
+          "title": "Arguments to the activity invocation"
+        },
+        "heartbeatDetails": {
+          "$ref": "#/definitions/v1Payloads",
+          "description": "Details of the last heartbeat that was recorded for this activity as of the time this task\nwas delivered."
+        },
+        "scheduledTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "When was this task first scheduled"
+        },
+        "currentAttemptScheduledTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "When was this task attempt scheduled"
+        },
+        "startedTime": {
+          "type": "string",
+          "format": "date-time",
+          "title": "When was this task started (this attempt)"
+        },
+        "attempt": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Starting at 1, the number of attempts to perform this activity"
+        },
+        "scheduleToCloseTimeout": {
+          "type": "string",
+          "title": "First scheduled -> final result reported timeout"
+        },
+        "startToCloseTimeout": {
+          "type": "string",
+          "title": "Current attempt start -> final result reported timeout"
+        },
+        "heartbeatTimeout": {
+          "type": "string",
+          "description": "Window within which the activity must report a heartbeat, or be timed out."
+        },
+        "retryPolicy": {
+          "$ref": "#/definitions/v1RetryPolicy",
+          "description": "This is the retry policy the service uses which may be different from the one provided\n(or not) during activity scheduling. The service can override the provided one if some\nvalues are not specified or exceed configured system limits."
+        },
+        "pollerScalingDecision": {
+          "$ref": "#/definitions/v1PollerScalingDecision",
+          "description": "Server-advised information the SDK may use to adjust its poller count."
+        },
+        "priority": {
+          "$ref": "#/definitions/v1Priority",
+          "title": "Priority metadata"
+        },
+        "activityRunId": {
+          "type": "string",
+          "description": "The run ID of the activity execution, only set for standalone activities."
+        }
+      }
+    },
+    "v1PollNexusTaskQueueResponse": {
+      "type": "object",
+      "properties": {
+        "taskToken": {
+          "type": "string",
+          "format": "byte",
+          "description": "An opaque unique identifier for this task for correlating a completion request the embedded request."
+        },
+        "request": {
+          "$ref": "#/definitions/apinexusv1Request",
+          "description": "Embedded request as translated from the incoming frontend request."
+        },
+        "pollerScalingDecision": {
+          "$ref": "#/definitions/v1PollerScalingDecision",
+          "description": "Server-advised information the SDK may use to adjust its poller count."
+        }
+      }
+    },
+    "v1PollWorkflowExecutionUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "$ref": "#/definitions/v1Outcome",
+          "description": "The outcome of the update if and only if the update has completed. If\nthis response is being returned before the update has completed (e.g. due\nto the specification of a wait policy that only waits on\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED) then this field will\nnot be set."
+        },
+        "stage": {
+          "$ref": "#/definitions/v1UpdateWorkflowExecutionLifecycleStage",
+          "description": "The most advanced lifecycle stage that the Update is known to have\nreached, where lifecycle stages are ordered\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED <\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED <\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED <\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.\nUNSPECIFIED will be returned if and only if the server's maximum wait\ntime was reached before the Update reached the stage specified in the\nrequest WaitPolicy, and before the context deadline expired; clients may\nmay then retry the call as needed."
+        },
+        "updateRef": {
+          "$ref": "#/definitions/v1UpdateRef",
+          "description": "Sufficient information to address this Update."
         }
       }
     },
@@ -15283,6 +16066,15 @@
       },
       "description": "Priority contains metadata that controls relative ordering of task processing\nwhen tasks are backed up in a queue. Initially, Priority will be used in\nmatching (workflow and activity) task queues. Later it may be used in history\ntask queues and in rate limiting decisions.\n\nPriority is attached to workflows and activities. By default, activities\ninherit Priority from the workflow that created them, but may override fields\nwhen an activity is started or modified.\n\nDespite being named \"Priority\", this message also contains fields that\ncontrol \"fairness\" mechanisms.\n\nFor all fields, the field not present or equal to zero/empty string means to\ninherit the value from the calling workflow, or if there is no calling\nworkflow, then use the default value.\n\nFor all fields other than fairness_key, the zero value isn't meaningful so\nthere's no confusion between inherit/default and a meaningful value. For\nfairness_key, the empty string will be interpreted as \"inherit\". This means\nthat if a workflow has a non-empty fairness key, you can't override the\nfairness key of its activity to the empty string.\n\nThe overall semantics of Priority are:\n1. First, consider \"priority\": higher priority (lower number) goes first.\n2. Then, consider fairness: try to dispatch tasks for different fairness keys\n   in proportion to their weight.\n\nApplications may use any subset of mechanisms that are useful to them and\nleave the other fields to use default values.\n\nNot all queues in the system may support the \"full\" semantics of all priority\nfields. (Currently only support in matching task queues is planned.)"
     },
+    "v1ProtocolMessageCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "messageId": {
+          "type": "string",
+          "description": "The message ID of the message to which this command is a pointer."
+        }
+      }
+    },
     "v1QueryRejectCondition": {
       "type": "string",
       "enum": [
@@ -15301,6 +16093,15 @@
           "$ref": "#/definitions/v1WorkflowExecutionStatus"
         }
       }
+    },
+    "v1QueryResultType": {
+      "type": "string",
+      "enum": [
+        "QUERY_RESULT_TYPE_UNSPECIFIED",
+        "QUERY_RESULT_TYPE_ANSWERED",
+        "QUERY_RESULT_TYPE_FAILED"
+      ],
+      "default": "QUERY_RESULT_TYPE_UNSPECIFIED"
     },
     "v1QueryWorkflowResponse": {
       "type": "object",
@@ -15410,6 +16211,26 @@
         }
       }
     },
+    "v1RecordMarkerCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "markerName": {
+          "type": "string"
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1Payloads"
+          }
+        },
+        "header": {
+          "$ref": "#/definitions/v1Header"
+        },
+        "failure": {
+          "$ref": "#/definitions/apifailurev1Failure"
+        }
+      }
+    },
     "v1RecordWorkerHeartbeatResponse": {
       "type": "object"
     },
@@ -15486,6 +16307,12 @@
       },
       "description": "ReleaseInfo contains information about specific version of temporal."
     },
+    "v1RemoveRemoteClusterResponse": {
+      "type": "object"
+    },
+    "v1RemoveSearchAttributesResponse": {
+      "type": "object"
+    },
     "v1ReplicationState": {
       "type": "string",
       "enum": [
@@ -15495,20 +16322,45 @@
       ],
       "default": "REPLICATION_STATE_UNSPECIFIED"
     },
-    "v1Request": {
-      "type": "object",
-      "properties": {
-        "meta": {
-          "$ref": "#/definitions/v1Meta"
-        },
-        "input": {
-          "$ref": "#/definitions/v1Input"
-        }
-      },
-      "description": "The client request that triggers a Workflow Update."
-    },
     "v1RequestCancelActivityExecutionResponse": {
       "type": "object"
+    },
+    "v1RequestCancelActivityTaskCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "scheduledEventId": {
+          "type": "string",
+          "format": "int64",
+          "description": "The `ACTIVITY_TASK_SCHEDULED` event id for the activity being cancelled."
+        }
+      }
+    },
+    "v1RequestCancelExternalWorkflowExecutionCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Deprecated. Cross-namespace operations are disabled by default as of server 1.30.1."
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "runId": {
+          "type": "string"
+        },
+        "control": {
+          "type": "string",
+          "description": "Deprecated."
+        },
+        "childWorkflowOnly": {
+          "type": "boolean",
+          "description": "Set this to true if the workflow being cancelled is a child of the workflow originating this\ncommand. The request will be rejected if it is set to true and the target workflow is *not*\na child of the requesting workflow."
+        },
+        "reason": {
+          "type": "string",
+          "title": "Reason for requesting the cancellation"
+        }
+      }
     },
     "v1RequestCancelExternalWorkflowExecutionFailedEventAttributes": {
       "type": "object",
@@ -15574,8 +16426,27 @@
         }
       }
     },
+    "v1RequestCancelNexusOperationCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "scheduledEventId": {
+          "type": "string",
+          "format": "int64",
+          "description": "The `NEXUS_OPERATION_SCHEDULED` event ID (a unique identifier) for the operation to be canceled.\nThe operation may ignore cancellation and end up with any completion state."
+        }
+      }
+    },
     "v1RequestCancelWorkflowExecutionResponse": {
       "type": "object"
+    },
+    "v1RequestCapabilities": {
+      "type": "object",
+      "properties": {
+        "temporalFailureResponses": {
+          "type": "boolean",
+          "description": "If set, handlers may use temporal.api.failure.v1.Failure instances to return failures to the server.\nThis also allows handler and operation errors to have their own messages and stack traces."
+        }
+      }
     },
     "v1RequestIdInfo": {
       "type": "object",
@@ -15710,6 +16581,9 @@
       "default": "RESET_REAPPLY_TYPE_UNSPECIFIED",
       "description": "Deprecated: applications should use ResetReapplyExcludeType to specify\nexclusions from this set, and new event types should be added to ResetReapplyExcludeType\ninstead of here.\n\n - RESET_REAPPLY_TYPE_SIGNAL: Signals are reapplied when workflow is reset.\n - RESET_REAPPLY_TYPE_NONE: No events are reapplied when workflow is reset.\n - RESET_REAPPLY_TYPE_ALL_ELIGIBLE: All eligible events are reapplied when workflow is reset."
     },
+    "v1ResetStickyTaskQueueResponse": {
+      "type": "object"
+    },
     "v1ResetType": {
       "type": "string",
       "enum": [
@@ -15755,7 +16629,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Failure"
+            "$ref": "#/definitions/apifailurev1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -15768,11 +16642,55 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Failure"
+            "$ref": "#/definitions/apifailurev1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
       }
+    },
+    "v1RespondNexusTaskCompletedResponse": {
+      "type": "object"
+    },
+    "v1RespondNexusTaskFailedResponse": {
+      "type": "object"
+    },
+    "v1RespondQueryTaskCompletedResponse": {
+      "type": "object"
+    },
+    "v1RespondWorkflowTaskCompletedRequestCapabilities": {
+      "type": "object",
+      "properties": {
+        "discardSpeculativeWorkflowTaskWithEvents": {
+          "type": "boolean",
+          "description": "True if the SDK can handle speculative workflow task with command events. If true, the\nserver may choose, at its discretion, to discard a speculative workflow task even if that\nspeculative task included command events the SDK had not previously processed.\n"
+        }
+      },
+      "description": "SDK capability details."
+    },
+    "v1RespondWorkflowTaskCompletedResponse": {
+      "type": "object",
+      "properties": {
+        "workflowTask": {
+          "$ref": "#/definitions/v1PollWorkflowTaskQueueResponse",
+          "title": "See `RespondWorkflowTaskCompletedResponse::return_new_workflow_task`"
+        },
+        "activityTasks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PollActivityTaskQueueResponse"
+          },
+          "title": "See `ScheduleActivityTaskCommandAttributes::request_eager_execution`"
+        },
+        "resetHistoryEventId": {
+          "type": "string",
+          "format": "int64",
+          "description": "If non zero, indicates the server has discarded the workflow task that was being responded to.\nWill be the event ID of the last workflow task started event in the history before the new workflow task.\nServer is only expected to discard a workflow task if it could not have modified the workflow state."
+        }
+      }
+    },
+    "v1RespondWorkflowTaskFailedResponse": {
+      "type": "object"
     },
     "v1RetryPolicy": {
       "type": "object",
@@ -15875,6 +16793,23 @@
       "default": "ROUTING_CONFIG_UPDATE_STATE_UNSPECIFIED",
       "description": "Indicates whether a change to the Routing Config has been\npropagated to all relevant Task Queues and their partitions.\n\n - ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS: Update to the RoutingConfig is currently in progress.\n - ROUTING_CONFIG_UPDATE_STATE_COMPLETED: Update to the RoutingConfig has completed successfully."
     },
+    "v1ScanWorkflowExecutionsResponse": {
+      "type": "object",
+      "properties": {
+        "executions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1WorkflowExecutionInfo"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "format": "byte"
+        }
+      },
+      "description": "Deprecated: Use with `ListWorkflowExecutions`."
+    },
     "v1Schedule": {
       "type": "object",
       "properties": {
@@ -15921,6 +16856,58 @@
         "startWorkflowStatus": {
           "$ref": "#/definitions/v1WorkflowExecutionStatus",
           "description": "If the action was start_workflow, this field will reflect an\neventually-consistent view of the started workflow's status."
+        }
+      }
+    },
+    "v1ScheduleActivityTaskCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "activityId": {
+          "type": "string"
+        },
+        "activityType": {
+          "$ref": "#/definitions/v1ActivityType"
+        },
+        "taskQueue": {
+          "$ref": "#/definitions/v1TaskQueue"
+        },
+        "header": {
+          "$ref": "#/definitions/v1Header"
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payloads"
+        },
+        "scheduleToCloseTimeout": {
+          "type": "string",
+          "description": "Indicates how long the caller is willing to wait for activity completion. The \"schedule\" time\nis when the activity is initially scheduled, not when the most recent retry is scheduled.\nLimits how long retries will be attempted. Either this or `start_to_close_timeout` must be\nspecified. When not specified, defaults to the workflow execution timeout.\n"
+        },
+        "scheduleToStartTimeout": {
+          "type": "string",
+          "title": "Limits the time an activity task can stay in a task queue before a worker picks it up. The\n\"schedule\" time is when the most recent retry is scheduled. This timeout should usually not\nbe set: it's useful in specific scenarios like worker-specific task queues. This timeout is\nalways non retryable, as all a retry would achieve is to put it back into the same queue.\nDefaults to `schedule_to_close_timeout` or workflow execution timeout if that is not\nspecified. More info:\nhttps://docs.temporal.io/docs/content/what-is-a-schedule-to-start-timeout/"
+        },
+        "startToCloseTimeout": {
+          "type": "string",
+          "description": "Maximum time an activity is allowed to execute after being picked up by a worker. This\ntimeout is always retryable. Either this or `schedule_to_close_timeout` must be specified.\n"
+        },
+        "heartbeatTimeout": {
+          "type": "string",
+          "description": "Maximum permitted time between successful worker heartbeats."
+        },
+        "retryPolicy": {
+          "$ref": "#/definitions/v1RetryPolicy",
+          "description": "Activities are provided by a default retry policy which is controlled through the service's\ndynamic configuration. Retries will be attempted until `schedule_to_close_timeout` has\nelapsed. To disable retries set retry_policy.maximum_attempts to 1."
+        },
+        "requestEagerExecution": {
+          "type": "boolean",
+          "description": "Request to start the activity directly bypassing matching service and worker polling\nThe slot for executing the activity should be reserved when setting this field to true."
+        },
+        "useWorkflowBuildId": {
+          "type": "boolean",
+          "description": "If this is set, the activity would be assigned to the Build ID of the workflow. Otherwise,\nAssignment rules of the activity's Task Queue will be used to determine the Build ID."
+        },
+        "priority": {
+          "$ref": "#/definitions/v1Priority",
+          "description": "Priority metadata. If this message is not present, or any fields are not\npresent, they inherit the values from the workflow."
         }
       }
     },
@@ -16044,6 +17031,46 @@
         }
       },
       "description": "ScheduleListInfo is an abbreviated set of values from Schedule and ScheduleInfo\nthat's returned in ListSchedules."
+    },
+    "v1ScheduleNexusOperationCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint name, must exist in the endpoint registry or this command will fail."
+        },
+        "service": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Operation name."
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Input for the operation. The server converts this into Nexus request content and the appropriate content headers\ninternally when sending the StartOperation request. On the handler side, if it is also backed by Temporal, the\ncontent is transformed back to the original Payload sent in this command."
+        },
+        "scheduleToCloseTimeout": {
+          "type": "string",
+          "description": "Schedule-to-close timeout for this operation.\nIndicates how long the caller is willing to wait for operation completion.\nCalls are retried internally by the server."
+        },
+        "nexusHeader": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Header to attach to the Nexus request.\nUsers are responsible for encrypting sensitive data in this header as it is stored in workflow history and\ntransmitted to external services as-is.\nThis is useful for propagating tracing information.\nNote these headers are not the same as Temporal headers on internal activities and child workflows, these are\ntransmitted to Nexus operations that may be external and are not traditional payloads."
+        },
+        "scheduleToStartTimeout": {
+          "type": "string",
+          "description": "Schedule-to-start timeout for this operation.\nIndicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)\nby the handler. If the operation is not started within this timeout, it will fail with\nTIMEOUT_TYPE_SCHEDULE_TO_START.\nIf not set or zero, no schedule-to-start timeout is enforced.\nRequires server version 1.31.0 or later."
+        },
+        "startToCloseTimeout": {
+          "type": "string",
+          "description": "Start-to-close timeout for this operation.\nIndicates how long the caller is willing to wait for an asynchronous operation to complete after it has been\nstarted. If the operation does not complete within this timeout after starting, it will fail with\nTIMEOUT_TYPE_START_TO_CLOSE.\nOnly applies to asynchronous operations. Synchronous operations ignore this timeout.\nIf not set or zero, no start-to-close timeout is enforced.\nRequires server version 1.31.0 or later."
+        }
+      }
     },
     "v1ScheduleOverlapPolicy": {
       "type": "string",
@@ -16297,6 +17324,41 @@
       ],
       "default": "SEVERITY_UNSPECIFIED"
     },
+    "v1ShutdownWorkerResponse": {
+      "type": "object"
+    },
+    "v1SignalExternalWorkflowExecutionCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Deprecated. Cross-namespace operations are disabled by default as of server 1.30.1."
+        },
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution"
+        },
+        "signalName": {
+          "type": "string",
+          "description": "The workflow author-defined name of the signal to send to the workflow."
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payloads",
+          "description": "Serialized value(s) to provide with the signal."
+        },
+        "control": {
+          "type": "string",
+          "title": "Deprecated"
+        },
+        "childWorkflowOnly": {
+          "type": "boolean",
+          "description": "Set this to true if the workflow being cancelled is a child of the workflow originating this\ncommand. The request will be rejected if it is set to true and the target workflow is *not*\na child of the requesting workflow."
+        },
+        "header": {
+          "$ref": "#/definitions/v1Header",
+          "description": "Headers that are passed by the workflow that is sending a signal to the external \nworkflow that is receiving this signal."
+        }
+      }
+    },
     "v1SignalExternalWorkflowExecutionFailedCause": {
       "type": "string",
       "enum": [
@@ -16409,6 +17471,74 @@
     },
     "v1StartBatchOperationResponse": {
       "type": "object"
+    },
+    "v1StartChildWorkflowExecutionCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Deprecated. Cross-namespace operations are disabled by default as of server 1.30.1."
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "workflowType": {
+          "$ref": "#/definitions/v1WorkflowType"
+        },
+        "taskQueue": {
+          "$ref": "#/definitions/v1TaskQueue"
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payloads"
+        },
+        "workflowExecutionTimeout": {
+          "type": "string",
+          "description": "Total workflow execution timeout including retries and continue as new."
+        },
+        "workflowRunTimeout": {
+          "type": "string",
+          "description": "Timeout of a single workflow run."
+        },
+        "workflowTaskTimeout": {
+          "type": "string",
+          "description": "Timeout of a single workflow task."
+        },
+        "parentClosePolicy": {
+          "$ref": "#/definitions/v1ParentClosePolicy",
+          "description": "Default: PARENT_CLOSE_POLICY_TERMINATE."
+        },
+        "control": {
+          "type": "string"
+        },
+        "workflowIdReusePolicy": {
+          "$ref": "#/definitions/v1WorkflowIdReusePolicy",
+          "description": "Default: WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE."
+        },
+        "retryPolicy": {
+          "$ref": "#/definitions/v1RetryPolicy"
+        },
+        "cronSchedule": {
+          "type": "string",
+          "description": "Establish a cron schedule for the child workflow."
+        },
+        "header": {
+          "$ref": "#/definitions/v1Header"
+        },
+        "memo": {
+          "$ref": "#/definitions/v1Memo"
+        },
+        "searchAttributes": {
+          "$ref": "#/definitions/v1SearchAttributes"
+        },
+        "inheritBuildId": {
+          "type": "boolean",
+          "description": "If this is set, the child workflow inherits the Build ID of the parent. Otherwise, the assignment\nrules of the child's Task Queue will be used to independently assign a Build ID to it.\nDeprecated. Only considered for versioning v0.2."
+        },
+        "priority": {
+          "$ref": "#/definitions/v1Priority",
+          "description": "Priority metadata. If this message is not present, or any fields are not\npresent, they inherit the values from the workflow."
+        }
+      }
     },
     "v1StartChildWorkflowExecutionFailedCause": {
       "type": "string",
@@ -16531,6 +17661,214 @@
         }
       }
     },
+    "v1StartOperationRequest": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "description": "Name of service to start the operation in."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Type of operation to start."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "A request ID that can be used as an idempotentency key."
+        },
+        "callback": {
+          "type": "string",
+          "description": "Callback URL to call upon completion if the started operation is async."
+        },
+        "payload": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Full request body from the incoming HTTP request."
+        },
+        "callbackHeader": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Header that is expected to be attached to the callback request when the operation completes."
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apinexusv1Link"
+          },
+          "description": "Links contain caller information and can be attached to the operations started by the handler."
+        }
+      },
+      "description": "A request to start an operation."
+    },
+    "v1StartOperationResponse": {
+      "type": "object",
+      "properties": {
+        "syncSuccess": {
+          "$ref": "#/definitions/StartOperationResponseSync"
+        },
+        "asyncSuccess": {
+          "$ref": "#/definitions/StartOperationResponseAsync"
+        },
+        "operationError": {
+          "$ref": "#/definitions/v1UnsuccessfulOperationError",
+          "description": "The operation completed unsuccessfully (failed or canceled).\nDeprecated. Use the failure variant instead."
+        },
+        "failure": {
+          "$ref": "#/definitions/apifailurev1Failure",
+          "description": "The operation completed unsuccessfully (failed or canceled).\nFailure object must contain an ApplicationFailureInfo or CanceledFailureInfo object."
+        }
+      },
+      "description": "Response variant for StartOperationRequest."
+    },
+    "v1StartTimeFilter": {
+      "type": "object",
+      "properties": {
+        "earliestTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "latestTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "v1StartTimerCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "timerId": {
+          "type": "string",
+          "description": "An id for the timer, currently live timers must have different ids. Typically autogenerated\nby the SDK."
+        },
+        "startToFireTimeout": {
+          "type": "string",
+          "description": "How long until the timer fires, producing a `TIMER_FIRED` event.\n"
+        }
+      }
+    },
+    "v1StartWorkflowExecutionRequest": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string"
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "workflowType": {
+          "$ref": "#/definitions/v1WorkflowType"
+        },
+        "taskQueue": {
+          "$ref": "#/definitions/v1TaskQueue"
+        },
+        "input": {
+          "$ref": "#/definitions/v1Payloads",
+          "description": "Serialized arguments to the workflow. These are passed as arguments to the workflow function."
+        },
+        "workflowExecutionTimeout": {
+          "type": "string",
+          "description": "Total workflow execution timeout including retries and continue as new."
+        },
+        "workflowRunTimeout": {
+          "type": "string",
+          "description": "Timeout of a single workflow run."
+        },
+        "workflowTaskTimeout": {
+          "type": "string",
+          "description": "Timeout of a single workflow task."
+        },
+        "identity": {
+          "type": "string",
+          "title": "The identity of the client who initiated this request"
+        },
+        "requestId": {
+          "type": "string",
+          "description": "A unique identifier for this start request. Typically UUIDv4."
+        },
+        "workflowIdReusePolicy": {
+          "$ref": "#/definitions/v1WorkflowIdReusePolicy",
+          "description": "Defines whether to allow re-using the workflow id from a previously *closed* workflow.\nThe default policy is WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE.\n\nSee `workflow_id_conflict_policy` for handling a workflow id duplication with a *running* workflow."
+        },
+        "workflowIdConflictPolicy": {
+          "$ref": "#/definitions/v1WorkflowIdConflictPolicy",
+          "description": "Defines how to resolve a workflow id conflict with a *running* workflow.\nThe default policy is WORKFLOW_ID_CONFLICT_POLICY_FAIL.\n\nSee `workflow_id_reuse_policy` for handling a workflow id duplication with a *closed* workflow."
+        },
+        "retryPolicy": {
+          "$ref": "#/definitions/v1RetryPolicy",
+          "description": "The retry policy for the workflow. Will never exceed `workflow_execution_timeout`."
+        },
+        "cronSchedule": {
+          "type": "string",
+          "title": "See https://docs.temporal.io/docs/content/what-is-a-temporal-cron-job/"
+        },
+        "memo": {
+          "$ref": "#/definitions/v1Memo"
+        },
+        "searchAttributes": {
+          "$ref": "#/definitions/v1SearchAttributes"
+        },
+        "header": {
+          "$ref": "#/definitions/v1Header"
+        },
+        "requestEagerExecution": {
+          "type": "boolean",
+          "description": "Request to get the first workflow task inline in the response bypassing matching service and worker polling.\nIf set to `true` the caller is expected to have a worker available and capable of processing the task.\nThe returned task will be marked as started and is expected to be completed by the specified\n`workflow_task_timeout`."
+        },
+        "continuedFailure": {
+          "$ref": "#/definitions/apifailurev1Failure",
+          "description": "These values will be available as ContinuedFailure and LastCompletionResult in the\nWorkflowExecutionStarted event and through SDKs. The are currently only used by the\nserver itself (for the schedules feature) and are not intended to be exposed in\nStartWorkflowExecution."
+        },
+        "lastCompletionResult": {
+          "$ref": "#/definitions/v1Payloads"
+        },
+        "workflowStartDelay": {
+          "type": "string",
+          "description": "Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.\nIf the workflow gets a signal before the delay, a workflow task will be dispatched and the rest\nof the delay will be ignored."
+        },
+        "completionCallbacks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Callback"
+          },
+          "description": "Callbacks to be called by the server when this workflow reaches a terminal state.\nIf the workflow continues-as-new, these callbacks will be carried over to the new execution.\nCallback addresses must be whitelisted in the server's dynamic configuration."
+        },
+        "userMetadata": {
+          "$ref": "#/definitions/v1UserMetadata",
+          "description": "Metadata on the workflow if it is started. This is carried over to the WorkflowExecutionInfo\nfor use by user interfaces to display the fixed as-of-start summary and details of the\nworkflow."
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apicommonv1Link"
+          },
+          "description": "Links to be associated with the workflow."
+        },
+        "versioningOverride": {
+          "$ref": "#/definitions/v1VersioningOverride",
+          "description": "If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.\nTo unset the override after the workflow is running, use UpdateWorkflowExecutionOptions."
+        },
+        "onConflictOptions": {
+          "$ref": "#/definitions/v1OnConflictOptions",
+          "description": "Defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
+        },
+        "priority": {
+          "$ref": "#/definitions/v1Priority",
+          "title": "Priority metadata"
+        },
+        "eagerWorkerDeploymentOptions": {
+          "$ref": "#/definitions/v1WorkerDeploymentOptions",
+          "description": "Deployment Options of the worker who will process the eager task. Passed when `request_eager_execution=true`."
+        },
+        "timeSkippingConfig": {
+          "$ref": "#/definitions/v1TimeSkippingConfig",
+          "description": "Time-skipping configuration. If not set, time skipping is disabled."
+        }
+      }
+    },
     "v1StartWorkflowExecutionResponse": {
       "type": "object",
       "properties": {
@@ -16551,8 +17889,27 @@
           "description": "When `request_eager_execution` is set on the `StartWorkflowExecutionRequest`, the server - if supported - will\nreturn the first workflow task to be eagerly executed.\nThe caller is expected to have a worker available to process the task."
         },
         "link": {
-          "$ref": "#/definitions/v1Link",
+          "$ref": "#/definitions/apicommonv1Link",
           "description": "Link to the workflow event."
+        }
+      }
+    },
+    "v1StatusFilter": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/v1WorkflowExecutionStatus"
+        }
+      }
+    },
+    "v1StickyExecutionAttributes": {
+      "type": "object",
+      "properties": {
+        "workerTaskQueue": {
+          "$ref": "#/definitions/v1TaskQueue"
+        },
+        "scheduleToStartTimeout": {
+          "type": "string"
         }
       }
     },
@@ -16705,6 +18062,28 @@
       ],
       "default": "TASK_QUEUE_KIND_UNSPECIFIED",
       "description": " - TASK_QUEUE_KIND_UNSPECIFIED: Tasks from any non workflow task may be unspecified.\n\nTask queue kind is used to differentiate whether a workflow task queue is sticky or \nnormal. If a task is not a workflow task, Task queue kind will sometimes be \nunspecified.\n - TASK_QUEUE_KIND_NORMAL: Tasks from a normal workflow task queue always include complete workflow history\n\nThe task queue specified by the user is always a normal task queue. There can be as many\nworkers as desired for a single normal task queue. All those workers may pick up tasks from\nthat queue.\n - TASK_QUEUE_KIND_STICKY: A sticky queue only includes new history since the last workflow task, and they are\nper-worker.\n\nSticky queues are created dynamically by each worker during their start up. They only exist\nfor the lifetime of the worker process. Tasks in a sticky task queue are only available to\nthe worker that created the sticky queue.\n\nSticky queues are only for workflow tasks. There are no sticky task queues for activities."
+    },
+    "v1TaskQueueMetadata": {
+      "type": "object",
+      "properties": {
+        "maxTasksPerSecond": {
+          "type": "number",
+          "format": "double",
+          "title": "Allows throttling dispatch of tasks from this queue"
+        }
+      },
+      "title": "Only applies to activity task queues"
+    },
+    "v1TaskQueuePartitionMetadata": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "ownerHostName": {
+          "type": "string"
+        }
+      }
     },
     "v1TaskQueueReachability": {
       "type": "object",
@@ -17047,6 +18426,18 @@
       "type": "object",
       "description": "Response to a successful UnpauseWorkflowExecution request."
     },
+    "v1UnsuccessfulOperationError": {
+      "type": "object",
+      "properties": {
+        "operationState": {
+          "type": "string",
+          "description": "See https://github.com/nexus-rpc/api/blob/main/SPEC.md#operationinfo."
+        },
+        "failure": {
+          "$ref": "#/definitions/apinexusv1Failure"
+        }
+      }
+    },
     "v1UpdateActivityOptionsResponse": {
       "type": "object",
       "properties": {
@@ -17159,6 +18550,10 @@
         }
       }
     },
+    "v1UpdateWorkerBuildIdCompatibilityResponse": {
+      "type": "object",
+      "title": "[cleanup-wv-pre-release]"
+    },
     "v1UpdateWorkerConfigResponse": {
       "type": "object",
       "properties": {
@@ -17180,6 +18575,31 @@
         }
       }
     },
+    "v1UpdateWorkerVersioningRulesResponse": {
+      "type": "object",
+      "properties": {
+        "assignmentRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TimestampedBuildIdAssignmentRule"
+          }
+        },
+        "compatibleRedirectRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1TimestampedCompatibleBuildIdRedirectRule"
+          }
+        },
+        "conflictToken": {
+          "type": "string",
+          "format": "byte",
+          "description": "This value can be passed back to UpdateWorkerVersioningRulesRequest to\nensure that the rules were not modified between the two updates, which\ncould lead to lost updates and other confusion."
+        }
+      },
+      "title": "[cleanup-wv-pre-release]"
+    },
     "v1UpdateWorkflowExecutionLifecycleStage": {
       "type": "string",
       "enum": [
@@ -17200,6 +18620,31 @@
         }
       }
     },
+    "v1UpdateWorkflowExecutionRequest": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "The namespace name of the target Workflow."
+        },
+        "workflowExecution": {
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "description": "The target Workflow Id and (optionally) a specific Run Id thereof."
+        },
+        "firstExecutionRunId": {
+          "type": "string",
+          "description": "If set, this call will error if the most recent (if no Run Id is set on\n`workflow_execution`), or specified (if it is) Workflow Execution is not\npart of the same execution chain as this Id."
+        },
+        "waitPolicy": {
+          "$ref": "#/definitions/v1WaitPolicy",
+          "description": "Specifies client's intent to wait for Update results.\nNOTE: This field works together with API call timeout which is limited by\nserver timeout (maximum wait time). If server timeout is expired before\nuser specified timeout, API call returns even if specified stage is not reached.\nActual reached stage will be included in the response."
+        },
+        "request": {
+          "$ref": "#/definitions/apiupdatev1Request",
+          "description": "The request information that will be delivered all the way down to the\nWorkflow Execution."
+        }
+      }
+    },
     "v1UpdateWorkflowExecutionResponse": {
       "type": "object",
       "properties": {
@@ -17214,6 +18659,14 @@
         "stage": {
           "$ref": "#/definitions/v1UpdateWorkflowExecutionLifecycleStage",
           "description": "The most advanced lifecycle stage that the Update is known to have\nreached, where lifecycle stages are ordered\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED <\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED <\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED <\nUPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.\nUNSPECIFIED will be returned if and only if the server's maximum wait\ntime was reached before the Update reached the stage specified in the\nrequest WaitPolicy, and before the context deadline expired; clients may\nmay then retry the call as needed."
+        }
+      }
+    },
+    "v1UpsertWorkflowSearchAttributesCommandAttributes": {
+      "type": "object",
+      "properties": {
+        "searchAttributes": {
+          "$ref": "#/definitions/v1SearchAttributes"
         }
       }
     },
@@ -17990,7 +19443,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "Deprecated. If a workflow's retry policy would cause a new run to start when the current one\nhas failed, this field would be populated with that failure. Now (when supported by server\nand sdk) the final event will be `WORKFLOW_EXECUTION_FAILED` with `new_execution_run_id` set."
         },
         "lastCompletionResult": {
@@ -18065,7 +19518,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "title": "Serialized result of workflow failure (ex: An exception thrown, or error returned)"
         },
         "retryState": {
@@ -18079,6 +19532,17 @@
         "newExecutionRunId": {
           "type": "string",
           "description": "If another run is started by cron or retry, this contains the new run id."
+        }
+      }
+    },
+    "v1WorkflowExecutionFilter": {
+      "type": "object",
+      "properties": {
+        "workflowId": {
+          "type": "string"
+        },
+        "runId": {
+          "type": "string"
         }
       }
     },
@@ -18354,7 +19818,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "continuedFailure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apifailurev1Failure"
         },
         "lastCompletionResult": {
           "$ref": "#/definitions/v1Payloads"
@@ -18563,7 +20027,7 @@
           "description": "The event ID used to sequence the original request message."
         },
         "acceptedRequest": {
-          "$ref": "#/definitions/v1Request",
+          "$ref": "#/definitions/apiupdatev1Request",
           "description": "The message payload of the original request message that initiated this\nupdate."
         }
       }
@@ -18572,7 +20036,7 @@
       "type": "object",
       "properties": {
         "request": {
-          "$ref": "#/definitions/v1Request",
+          "$ref": "#/definitions/apiupdatev1Request",
           "description": "The update request associated with this event."
         },
         "origin": {
@@ -18616,11 +20080,11 @@
           "description": "The event ID used to sequence the original request message."
         },
         "rejectedRequest": {
-          "$ref": "#/definitions/v1Request",
+          "$ref": "#/definitions/apiupdatev1Request",
           "description": "The message payload of the original request message that initiated this\nupdate."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "description": "The cause of rejection."
         }
       }
@@ -18744,6 +20208,28 @@
         }
       },
       "title": "See https://docs.temporal.io/docs/concepts/queries/"
+    },
+    "v1WorkflowQueryResult": {
+      "type": "object",
+      "properties": {
+        "resultType": {
+          "$ref": "#/definitions/v1QueryResultType",
+          "title": "Did the query succeed or fail?"
+        },
+        "answer": {
+          "$ref": "#/definitions/v1Payloads",
+          "description": "Set when the query succeeds with the results.\nMutually exclusive with `error_message` and `failure`."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Mutually exclusive with `answer`. Set when the query fails.\nSee also the newer `failure` field."
+        },
+        "failure": {
+          "$ref": "#/definitions/apifailurev1Failure",
+          "description": "The full reason for this query failure. This field is newer than `error_message` and can be encoded by the SDK's\nfailure converter to support E2E encryption of messages and stack traces.\nMutually exclusive with `answer`. Set when the query fails."
+        }
+      },
+      "title": "Answer to a `WorkflowQuery`"
     },
     "v1WorkflowRule": {
       "type": "object",
@@ -18952,7 +20438,7 @@
           "$ref": "#/definitions/v1WorkflowTaskFailedCause"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apifailurev1Failure",
           "title": "The failure details"
         },
         "identity": {
@@ -19073,6 +20559,14 @@
         }
       },
       "title": "Represents the identifier used by a workflow author to define the workflow. Typically, the\nname of a function. This is sometimes referred to as the workflow's \"name\""
+    },
+    "v1WorkflowTypeFilter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12685,9 +12685,10 @@ components:
         firstExecutionRunId:
           type: string
           description: |-
-            If set, this call will error if the most recent (if no run id is set on
-             `workflow_execution`), or specified (if it is) workflow execution is not part of the same
-             execution chain as this id.
+            If set, the run id on `workflow_execution` is ignored and the most recent
+             workflow execution for the given workflow id is resolved. This call will
+             then error if that execution is not part of the same execution chain as
+             this id.
         reason:
           type: string
           description: Reason for requesting the cancellation
@@ -14944,9 +14945,10 @@ components:
         firstExecutionRunId:
           type: string
           description: |-
-            If set, this call will error if the most recent (if no run id is set on
-             `workflow_execution`), or specified (if it is) workflow execution is not part of the same
-             execution chain as this id.
+            If set, the run id on `workflow_execution` is ignored and the most recent
+             workflow execution for the given workflow id is resolved. This call will
+             then error if that execution is not part of the same execution chain as
+             this id.
         links:
           type: array
           items:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -737,9 +737,10 @@ message RequestCancelWorkflowExecutionRequest {
     string identity = 3;
     // Used to de-dupe cancellation requests
     string request_id = 4;
-    // If set, this call will error if the most recent (if no run id is set on
-    // `workflow_execution`), or specified (if it is) workflow execution is not part of the same
-    // execution chain as this id.
+    // If set, the run id on `workflow_execution` is ignored and the most recent
+    // workflow execution for the given workflow id is resolved. This call will
+    // then error if that execution is not part of the same execution chain as
+    // this id.
     string first_execution_run_id = 5;
     // Reason for requesting the cancellation
     string reason = 6;
@@ -887,9 +888,10 @@ message TerminateWorkflowExecutionRequest {
     temporal.api.common.v1.Payloads details = 4;
     // The identity of the worker/client
     string identity = 5;
-    // If set, this call will error if the most recent (if no run id is set on
-    // `workflow_execution`), or specified (if it is) workflow execution is not part of the same
-    // execution chain as this id.
+    // If set, the run id on `workflow_execution` is ignored and the most recent
+    // workflow execution for the given workflow id is resolved. This call will
+    // then error if that execution is not part of the same execution chain as
+    // this id.
     string first_execution_run_id = 6;
 
     // Links to be associated with the WorkflowExecutionTerminated event.


### PR DESCRIPTION
The proto comments on `first_execution_run_id` in `RequestCancelWorkflowExecutionRequest` and `TerminateWorkflowExecutionRequest` claimed that when a run ID is set on `workflow_execution`, validation would demand that that run descends from `first_execution_run_id`. In reality, the server unconditionally ignores the `workflow_execution` run ID when `first_execution_run_id` is set, resolves to the most recent execution, and then checks that *that* descends from `first_execution_run_id`:

[`requestcancelworkflow/api.go:32-34`](https://github.com/temporalio/temporal/blob/f8bbf7c7803874fe454c6db270dfbe2f69bd9e79/service/history/api/requestcancelworkflow/api.go#L32-L34)
```go
if len(firstExecutionRunID) != 0 {
    runID = ""
}
```

[`terminateworkflow/api.go:33-35`](https://github.com/temporalio/temporal/blob/f8bbf7c7803874fe454c6db270dfbe2f69bd9e79/service/history/api/terminateworkflow/api.go#L33-L35)
```go
if len(request.FirstExecutionRunId) != 0 {
    runID = ""
}
```

The `UpdateWorkflowExecutionRequest` comment is left unchanged because its [server implementation](https://github.com/temporalio/temporal/blob/f8bbf7c7803874fe454c6db270dfbe2f69bd9e79/service/history/api/updateworkflow/api.go#L77-L81) does pass the `workflow_execution` run ID through to execution resolution, and validates `first_execution_run_id` separately [after loading the execution](https://github.com/temporalio/temporal/blob/f8bbf7c7803874fe454c6db270dfbe2f69bd9e79/service/history/api/updateworkflow/api.go#L109-L111).