### PR TITLE
Patch v1.61.0 release with the fixed API route clashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
             git diff
             exit 1
           fi
+      - name: Check for OpenAPI path conflicts
+        run: go run ./cmd/check-path-conflicts/main.go openapi/openapiv2.json

--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,11 @@ buf-lint: $(STAMPDIR)/buf-mod-prune
 	printf $(COLOR) "Run buf linter..."
 	(cd $(PROTO_ROOT) && buf lint)
 
+BUF_BREAKING_BRANCH ?= $(or $(GITHUB_BASE_REF),master)
+
 buf-breaking:
-	@printf $(COLOR) "Run buf breaking changes check against master branch..."	
-	@(cd $(PROTO_ROOT) && buf breaking --against 'https://github.com/temporalio/api.git#branch=master')
+	@printf $(COLOR) "Run buf breaking changes check against $(BUF_BREAKING_BRANCH) branch..."
+	@(cd $(PROTO_ROOT) && buf breaking --against 'https://github.com/temporalio/api.git#branch=$(BUF_BREAKING_BRANCH)')
 
 ##### Clean #####
 clean:

--- a/cmd/check-path-conflicts/main.go
+++ b/cmd/check-path-conflicts/main.go
@@ -1,0 +1,137 @@
+// check-path-conflicts reads an OpenAPI v2 JSON file and detects HTTP path
+// conflicts where a literal path segment and a parameterized segment overlap at
+// the same position (e.g. /items/pause vs /items/{id}).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+type openAPISpec struct {
+	Paths map[string]map[string]json.RawMessage `json:"paths"`
+}
+
+// httpMethods are the valid HTTP method keys in an OpenAPI path item.
+var httpMethods = map[string]bool{
+	"get": true, "put": true, "post": true, "delete": true,
+	"options": true, "head": true, "patch": true,
+}
+
+// segment represents one piece of a URL path.
+type segment struct {
+	value string
+	param bool // true when the segment is a path parameter like {id}
+}
+
+func parseSegments(path string) []segment {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	segs := make([]segment, len(parts))
+	for i, p := range parts {
+		segs[i] = segment{
+			value: p,
+			param: strings.HasPrefix(p, "{") && strings.HasSuffix(p, "}"),
+		}
+	}
+	return segs
+}
+
+// Two paths conflict when they have the same number of segments and at every
+// position, they either match literally or at least one of them is a parameter,
+// AND there is at least one position where one path has a literal and the other
+// has a parameter (otherwise they are the same path or differ only in parameter
+// names, which is a different issue).
+func conflicts(a, b []segment) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	hasParamLiteralMismatch := false
+	for i := range a {
+		aParam := a[i].param
+		bParam := b[i].param
+		if !aParam && !bParam {
+			// Both literals — must match exactly.
+			if a[i].value != b[i].value {
+				return false
+			}
+		} else if aParam != bParam {
+			// One is a param, the other is a literal — potential conflict.
+			hasParamLiteralMismatch = true
+		}
+		// Both params — always compatible at this position, continue.
+	}
+	return hasParamLiteralMismatch
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <openapi-v2.json>\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	data, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading file: %v\n", err)
+		os.Exit(2)
+	}
+
+	var spec openAPISpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing JSON: %v\n", err)
+		os.Exit(2)
+	}
+
+	type parsedPath struct {
+		raw      string
+		methods  map[string]bool
+		segments []segment
+	}
+
+	var parsed []parsedPath
+	for p, item := range spec.Paths {
+		methods := make(map[string]bool)
+		for key := range item {
+			if httpMethods[strings.ToLower(key)] {
+				methods[strings.ToLower(key)] = true
+			}
+		}
+		parsed = append(parsed, parsedPath{raw: p, methods: methods, segments: parseSegments(p)})
+	}
+	sort.Slice(parsed, func(i, j int) bool { return parsed[i].raw < parsed[j].raw })
+
+	var found []string
+	for i := 0; i < len(parsed); i++ {
+		for j := i + 1; j < len(parsed); j++ {
+			if !conflicts(parsed[i].segments, parsed[j].segments) {
+				continue
+			}
+			// Find overlapping HTTP methods.
+			var shared []string
+			for m := range parsed[i].methods {
+				if parsed[j].methods[m] {
+					shared = append(shared, strings.ToUpper(m))
+				}
+			}
+			if len(shared) == 0 {
+				continue
+			}
+			sort.Strings(shared)
+			found = append(found, fmt.Sprintf("  %s\n  %s\n  methods: %s",
+				parsed[i].raw, parsed[j].raw, strings.Join(shared, ", ")))
+		}
+	}
+
+	if len(found) > 0 {
+		fmt.Fprintf(os.Stderr, "found %d path conflict(s):\n\n", len(found))
+		for _, f := range found {
+			fmt.Fprintln(os.Stderr, f)
+			fmt.Fprintln(os.Stderr)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println("no path conflicts found")
+}

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -211,327 +211,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/cancel": {
-      "post": {
-        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
-        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "RespondActivityTaskCanceled2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCanceledResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/cancel-by-id": {
-      "post": {
-        "summary": "See `RespondActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RespondActivityTaskCanceledById2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCanceledByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/complete": {
-      "post": {
-        "summary": "RespondActivityTaskCompleted is called by workers when they successfully complete an activity\ntask.",
-        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "RespondActivityTaskCompleted2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCompletedResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/complete-by-id": {
-      "post": {
-        "summary": "See `RespondActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RespondActivityTaskCompletedById2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCompletedByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/fail": {
-      "post": {
-        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
-        "description": "This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and\na new workflow task created for the workflow. Fails with `NotFound` if the task token is no\nlonger valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "RespondActivityTaskFailed2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskFailedResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/fail-by-id": {
-      "post": {
-        "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RespondActivityTaskFailedById2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskFailedByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/heartbeat": {
-      "post": {
-        "summary": "RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.",
-        "description": "If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,\nthen the current attempt times out. Depending on RetryPolicy, this may trigger a retry or\ntime out the activity.\n\nFor workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow\nhistory. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,\nin that event, the SDK should request cancellation of the activity.\n\nThe request may contain response `details` which will be persisted by the server and may be\nused by the activity to checkpoint progress. The `cancel_requested` field in the response\nindicates whether cancellation has been requested for the activity.",
-        "operationId": "RecordActivityTaskHeartbeat2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/heartbeat-by-id": {
-      "post": {
-        "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RecordActivityTaskHeartbeatById2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/api/v1/namespaces/{namespace}/activities/pause": {
+    "/api/v1/namespaces/{namespace}/activities-deprecated/pause": {
       "post": {
         "summary": "PauseActivity pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused",
         "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type\nThis API will be deprecated soon and replaced with a newer PauseActivityExecution that is better named and\nstructured to work well for standalone activities.",
@@ -572,7 +252,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/reset": {
+    "/api/v1/namespaces/{namespace}/activities-deprecated/reset": {
       "post": {
         "summary": "ResetActivity resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
         "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpaused, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.\nThis API will be deprecated soon and replaced with a newer ResetActivityExecution that is better named and\nstructured to work well for standalone activities.",
@@ -613,7 +293,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/unpause": {
+    "/api/v1/namespaces/{namespace}/activities-deprecated/unpause": {
       "post": {
         "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpaused.",
         "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpaused, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type\nThis API will be deprecated soon and replaced with a newer UnpauseActivityExecution that is better named and\nstructured to work well for standalone activities.",
@@ -654,7 +334,7 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/activities/update-options": {
+    "/api/v1/namespaces/{namespace}/activities-deprecated/update-options": {
       "post": {
         "summary": "UpdateActivityOptions is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.\nThis API will be deprecated soon and replaced with a newer UpdateActivityExecutionOptions that is better named and\nstructured to work well for standalone activities.",
         "operationId": "UpdateActivityOptions2",
@@ -851,6 +531,147 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/activities/{activityId}/complete": {
+      "post": {
+        "summary": "See `RespondActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCompletedById2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCompletedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to complete",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/activities/{activityId}/fail": {
+      "post": {
+        "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskFailedById2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskFailedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to fail",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/activities/{activityId}/heartbeat": {
+      "post": {
+        "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RecordActivityTaskHeartbeatById2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity we're heartbeating",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/activities/{activityId}/outcome": {
       "get": {
         "summary": "PollActivityExecution long-polls for an activity execution to complete and returns the\noutcome (result or failure).",
@@ -888,6 +709,53 @@
             "in": "query",
             "required": false,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/activities/{activityId}/resolve-as-canceled": {
+      "post": {
+        "summary": "See `RespondActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCanceledById2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCanceledByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to confirm is cancelled",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledByIdBody"
+            }
           }
         ],
         "tags": [
@@ -941,6 +809,46 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/activity-complete": {
+      "post": {
+        "summary": "RespondActivityTaskCompleted is called by workers when they successfully complete an activity\ntask.",
+        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
+        "operationId": "RespondActivityTaskCompleted2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCompletedResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/activity-count": {
       "get": {
         "summary": "CountActivityExecutions is a visibility API to count activity executions in a specific namespace.",
@@ -972,6 +880,126 @@
             "in": "query",
             "required": false,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/activity-fail": {
+      "post": {
+        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
+        "description": "This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and\na new workflow task created for the workflow. Fails with `NotFound` if the task token is no\nlonger valid due to activity timeout, already being completed, or never having existed.",
+        "operationId": "RespondActivityTaskFailed2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskFailedResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/activity-heartbeat": {
+      "post": {
+        "summary": "RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.",
+        "description": "If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,\nthen the current attempt times out. Depending on RetryPolicy, this may trigger a retry or\ntime out the activity.\n\nFor workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow\nhistory. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,\nin that event, the SDK should request cancellation of the activity.\n\nThe request may contain response `details` which will be persisted by the server and may be\nused by the activity to checkpoint progress. The `cancel_requested` field in the response\nindicates whether cancellation has been requested for the activity.",
+        "operationId": "RecordActivityTaskHeartbeat2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/activity-resolve-as-canceled": {
+      "post": {
+        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
+        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
+        "operationId": "RespondActivityTaskCanceled2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCanceledResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledBody"
+            }
           }
         ],
         "tags": [
@@ -3691,6 +3719,269 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/complete": {
+      "post": {
+        "summary": "See `RespondActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCompletedById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCompletedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to complete",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/fail": {
+      "post": {
+        "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskFailedById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskFailedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to fail",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/heartbeat": {
+      "post": {
+        "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RecordActivityTaskHeartbeatById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity we're heartbeating",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/resolve-as-canceled": {
+      "post": {
+        "summary": "See `RespondActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCanceledById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCanceledByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to confirm is cancelled",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/pause": {
+      "post": {
+        "summary": "Note: This is an experimental API and the behavior may change in a future release.\nPauseWorkflowExecution pauses the workflow execution specified in the request. Pausing a workflow execution results in\n- The workflow execution status changes to `PAUSED` and a new WORKFLOW_EXECUTION_PAUSED event is added to the history\n- No new workflow tasks or activity tasks are dispatched.\n  - Any workflow task currently executing on the worker will be allowed to complete.\n  - Any activity task currently executing will be paused.\n- All server-side events will continue to be processed by the server.\n- Queries & Updates on a paused workflow will be rejected.",
+        "operationId": "PauseWorkflowExecution2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1PauseWorkflowExecutionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow to pause.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "ID of the workflow execution to be paused. Required.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServicePauseWorkflowExecutionBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/workflows/{workflowId}/signal-with-start/{signalName}": {
       "post": {
         "summary": "SignalWithStartWorkflowExecution is used to ensure a signal is sent to a workflow, even if\nit isn't yet started.",
@@ -4405,327 +4696,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/cancel": {
-      "post": {
-        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
-        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "RespondActivityTaskCanceled",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCanceledResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/cancel-by-id": {
-      "post": {
-        "summary": "See `RespondActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RespondActivityTaskCanceledById",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCanceledByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/complete": {
-      "post": {
-        "summary": "RespondActivityTaskCompleted is called by workers when they successfully complete an activity\ntask.",
-        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "RespondActivityTaskCompleted",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCompletedResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/complete-by-id": {
-      "post": {
-        "summary": "See `RespondActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RespondActivityTaskCompletedById",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskCompletedByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/fail": {
-      "post": {
-        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
-        "description": "This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and\na new workflow task created for the workflow. Fails with `NotFound` if the task token is no\nlonger valid due to activity timeout, already being completed, or never having existed.",
-        "operationId": "RespondActivityTaskFailed",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskFailedResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/fail-by-id": {
-      "post": {
-        "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RespondActivityTaskFailedById",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RespondActivityTaskFailedByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/heartbeat": {
-      "post": {
-        "summary": "RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.",
-        "description": "If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,\nthen the current attempt times out. Depending on RetryPolicy, this may trigger a retry or\ntime out the activity.\n\nFor workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow\nhistory. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,\nin that event, the SDK should request cancellation of the activity.\n\nThe request may contain response `details` which will be persisted by the server and may be\nused by the activity to checkpoint progress. The `cancel_requested` field in the response\nindicates whether cancellation has been requested for the activity.",
-        "operationId": "RecordActivityTaskHeartbeat",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/heartbeat-by-id": {
-      "post": {
-        "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
-        "operationId": "RecordActivityTaskHeartbeatById",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatByIdResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "description": "Namespace of the workflow which scheduled this activity",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatByIdBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
-    "/namespaces/{namespace}/activities/pause": {
+    "/namespaces/{namespace}/activities-deprecated/pause": {
       "post": {
         "summary": "PauseActivity pauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be paused",
         "description": "Pausing an activity means:\n- If the activity is currently waiting for a retry or is running and subsequently fails,\n  it will not be rescheduled until it is unpaused.\n- If the activity is already paused, calling this method will have no effect.\n- If the activity is running and finishes successfully, the activity will be completed.\n- If the activity is running and finishes with failure:\n  * if there is no retry left - the activity will be completed.\n  * if there are more retries left - the activity will be paused.\nFor long-running activities:\n- activities in paused state will send a cancellation with \"activity_paused\" set to 'true' in response to 'RecordActivityTaskHeartbeat'.\n- The activity should respond to the cancellation accordingly.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type\nThis API will be deprecated soon and replaced with a newer PauseActivityExecution that is better named and\nstructured to work well for standalone activities.",
@@ -4766,7 +4737,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/reset": {
+    "/namespaces/{namespace}/activities-deprecated/reset": {
       "post": {
         "summary": "ResetActivity resets the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be reset.",
         "description": "Resetting an activity means:\n* number of attempts will be reset to 0.\n* activity timeouts will be reset.\n* if the activity is waiting for retry, and it is not paused or 'keep_paused' is not provided:\n   it will be scheduled immediately (* see 'jitter' flag),\n\nFlags:\n\n'jitter': the activity will be scheduled at a random time within the jitter duration.\nIf the activity currently paused it will be unpaused, unless 'keep_paused' flag is provided.\n'reset_heartbeats': the activity heartbeat timer and heartbeats will be reset.\n'keep_paused': if the activity is paused, it will remain paused.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type.\nThis API will be deprecated soon and replaced with a newer ResetActivityExecution that is better named and\nstructured to work well for standalone activities.",
@@ -4807,7 +4778,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/unpause": {
+    "/namespaces/{namespace}/activities-deprecated/unpause": {
       "post": {
         "summary": "UnpauseActivity unpauses the execution of an activity specified by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be unpaused.",
         "description": "If activity is not paused, this call will have no effect.\nIf the activity was paused while waiting for retry, it will be scheduled immediately (* see 'jitter' flag).\nOnce the activity is unpaused, all timeout timers will be regenerated.\n\nFlags:\n'jitter': the activity will be scheduled at a random time within the jitter duration.\n'reset_attempts': the number of attempts will be reset.\n'reset_heartbeat': the activity heartbeat timer and heartbeats will be reset.\n\nReturns a `NotFound` error if there is no pending activity with the provided ID or type\nThis API will be deprecated soon and replaced with a newer UnpauseActivityExecution that is better named and\nstructured to work well for standalone activities.",
@@ -4848,7 +4819,7 @@
         ]
       }
     },
-    "/namespaces/{namespace}/activities/update-options": {
+    "/namespaces/{namespace}/activities-deprecated/update-options": {
       "post": {
         "summary": "UpdateActivityOptions is called by the client to update the options of an activity by its ID or type.\nIf there are multiple pending activities of the provided type - all of them will be updated.\nThis API will be deprecated soon and replaced with a newer UpdateActivityExecutionOptions that is better named and\nstructured to work well for standalone activities.",
         "operationId": "UpdateActivityOptions",
@@ -5045,6 +5016,147 @@
         ]
       }
     },
+    "/namespaces/{namespace}/activities/{activityId}/complete": {
+      "post": {
+        "summary": "See `RespondActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCompletedById",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCompletedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to complete",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/activities/{activityId}/fail": {
+      "post": {
+        "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskFailedById",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskFailedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to fail",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/activities/{activityId}/heartbeat": {
+      "post": {
+        "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RecordActivityTaskHeartbeatById",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity we're heartbeating",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/activities/{activityId}/outcome": {
       "get": {
         "summary": "PollActivityExecution long-polls for an activity execution to complete and returns the\noutcome (result or failure).",
@@ -5082,6 +5194,53 @@
             "in": "query",
             "required": false,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/activities/{activityId}/resolve-as-canceled": {
+      "post": {
+        "summary": "See `RespondActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCanceledById",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCanceledByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to confirm is cancelled",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledByIdBody"
+            }
           }
         ],
         "tags": [
@@ -5135,6 +5294,46 @@
         ]
       }
     },
+    "/namespaces/{namespace}/activity-complete": {
+      "post": {
+        "summary": "RespondActivityTaskCompleted is called by workers when they successfully complete an activity\ntask.",
+        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
+        "operationId": "RespondActivityTaskCompleted",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCompletedResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/activity-count": {
       "get": {
         "summary": "CountActivityExecutions is a visibility API to count activity executions in a specific namespace.",
@@ -5166,6 +5365,126 @@
             "in": "query",
             "required": false,
             "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/activity-fail": {
+      "post": {
+        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
+        "description": "This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and\na new workflow task created for the workflow. Fails with `NotFound` if the task token is no\nlonger valid due to activity timeout, already being completed, or never having existed.",
+        "operationId": "RespondActivityTaskFailed",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskFailedResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/activity-heartbeat": {
+      "post": {
+        "summary": "RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.",
+        "description": "If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,\nthen the current attempt times out. Depending on RetryPolicy, this may trigger a retry or\ntime out the activity.\n\nFor workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow\nhistory. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,\nin that event, the SDK should request cancellation of the activity.\n\nThe request may contain response `details` which will be persisted by the server and may be\nused by the activity to checkpoint progress. The `cancel_requested` field in the response\nindicates whether cancellation has been requested for the activity.",
+        "operationId": "RecordActivityTaskHeartbeat",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/activity-resolve-as-canceled": {
+      "post": {
+        "summary": "RespondActivityTaskFailed is called by workers when processing an activity task fails.",
+        "description": "For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history\nand a new workflow task created for the workflow. Fails with `NotFound` if the task token is\nno longer valid due to activity timeout, already being completed, or never having existed.",
+        "operationId": "RespondActivityTaskCanceled",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCanceledResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledBody"
+            }
           }
         ],
         "tags": [
@@ -7815,6 +8134,222 @@
         ]
       }
     },
+    "/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/complete": {
+      "post": {
+        "summary": "See `RespondActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCompletedById3",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCompletedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to complete",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/fail": {
+      "post": {
+        "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskFailedById3",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskFailedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to fail",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/heartbeat": {
+      "post": {
+        "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RecordActivityTaskHeartbeatById3",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity we're heartbeating",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/resolve-as-canceled": {
+      "post": {
+        "summary": "See `RespondActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCanceledById3",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCanceledByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to confirm is cancelled",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/workflows/{workflowId}/pause": {
       "post": {
         "summary": "Note: This is an experimental API and the behavior may change in a future release.\nPauseWorkflowExecution pauses the workflow execution specified in the request. Pausing a workflow execution results in\n- The workflow execution status changes to `PAUSED` and a new WORKFLOW_EXECUTION_PAUSED event is added to the history\n- No new workflow tasks or activity tasks are dispatched.\n  - Any workflow task currently executing on the worker will be allowed to complete.\n  - Any activity task currently executing will be paused.\n- All server-side events will continue to be processed by the server.\n- Queries & Updates on a paused workflow will be rejected.",
@@ -8644,17 +9179,9 @@
     "WorkflowServiceRecordActivityTaskHeartbeatByIdBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "title": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity"
-        },
         "runId": {
           "type": "string",
           "description": "For a workflow activity - the run ID of the workflow which scheduled this activity.\nFor a standalone activity - the run ID of the activity."
-        },
-        "activityId": {
-          "type": "string",
-          "title": "Id of the activity we're heartbeating"
         },
         "details": {
           "$ref": "#/definitions/v1Payloads",
@@ -8865,17 +9392,9 @@
     "WorkflowServiceRespondActivityTaskCanceledByIdBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "title": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity"
-        },
         "runId": {
           "type": "string",
           "description": "For a workflow activity - the run ID of the workflow which scheduled this activity.\nFor a standalone activity - the run ID of the activity."
-        },
-        "activityId": {
-          "type": "string",
-          "title": "Id of the activity to confirm is cancelled"
         },
         "details": {
           "$ref": "#/definitions/v1Payloads",
@@ -8924,17 +9443,9 @@
     "WorkflowServiceRespondActivityTaskCompletedByIdBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "title": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity"
-        },
         "runId": {
           "type": "string",
           "description": "For a workflow activity - the run ID of the workflow which scheduled this activity.\nFor a standalone activity - the run ID of the activity."
-        },
-        "activityId": {
-          "type": "string",
-          "title": "Id of the activity to complete"
         },
         "result": {
           "$ref": "#/definitions/v1Payloads",
@@ -8983,17 +9494,9 @@
     "WorkflowServiceRespondActivityTaskFailedByIdBody": {
       "type": "object",
       "properties": {
-        "workflowId": {
-          "type": "string",
-          "title": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity"
-        },
         "runId": {
           "type": "string",
           "description": "For a workflow activity - the run ID of the workflow which scheduled this activity.\nFor a standalone activity - the run ID of the activity."
-        },
-        "activityId": {
-          "type": "string",
-          "title": "Id of the activity to fail"
         },
         "failure": {
           "$ref": "#/definitions/apiFailureV1Failure",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -3076,46 +3076,6 @@
         ]
       }
     },
-    "/api/v1/namespaces/{namespace}/workflows/execute-multi-operation": {
-      "post": {
-        "summary": "ExecuteMultiOperation executes multiple operations within a single workflow.",
-        "description": "Operations are started atomically, meaning if *any* operation fails to be started, none are,\nand the request fails. Upon start, the API returns only when *all* operations have a response.\n\nUpon failure, it returns `MultiOperationExecutionFailure` where the status code\nequals the status code of the *first* operation that failed to be started.\n\nNOTE: Experimental API.",
-        "operationId": "ExecuteMultiOperation2",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ExecuteMultiOperationResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceExecuteMultiOperationBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}": {
       "get": {
         "summary": "DescribeWorkflowExecution returns information about the specified workflow execution.",
@@ -7240,46 +7200,6 @@
         ]
       }
     },
-    "/namespaces/{namespace}/workflows/execute-multi-operation": {
-      "post": {
-        "summary": "ExecuteMultiOperation executes multiple operations within a single workflow.",
-        "description": "Operations are started atomically, meaning if *any* operation fails to be started, none are,\nand the request fails. Upon start, the API returns only when *all* operations have a response.\n\nUpon failure, it returns `MultiOperationExecutionFailure` where the status code\nequals the status code of the *first* operation that failed to be started.\n\nNOTE: Experimental API.",
-        "operationId": "ExecuteMultiOperation",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1ExecuteMultiOperationResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WorkflowServiceExecuteMultiOperationBody"
-            }
-          }
-        ],
-        "tags": [
-          "WorkflowService"
-        ]
-      }
-    },
     "/namespaces/{namespace}/workflows/{execution.workflowId}": {
       "get": {
         "summary": "DescribeWorkflowExecution returns information about the specified workflow execution.",
@@ -8182,30 +8102,6 @@
       },
       "description": "Target a worker polling on a Nexus task queue in a specific namespace."
     },
-    "ExecuteMultiOperationRequestOperation": {
-      "type": "object",
-      "properties": {
-        "startWorkflow": {
-          "$ref": "#/definitions/v1StartWorkflowExecutionRequest",
-          "title": "Additional restrictions:\n- setting `cron_schedule` is invalid\n- setting `request_eager_execution` is invalid\n- setting `workflow_start_delay` is invalid"
-        },
-        "updateWorkflow": {
-          "$ref": "#/definitions/v1UpdateWorkflowExecutionRequest",
-          "title": "Additional restrictions:\n- setting `first_execution_run_id` is invalid\n- setting `workflow_execution.run_id` is invalid"
-        }
-      }
-    },
-    "ExecuteMultiOperationResponseResponse": {
-      "type": "object",
-      "properties": {
-        "startWorkflow": {
-          "$ref": "#/definitions/v1StartWorkflowExecutionResponse"
-        },
-        "updateWorkflow": {
-          "$ref": "#/definitions/v1UpdateWorkflowExecutionResponse"
-        }
-      }
-    },
     "LinkBatchJob": {
       "type": "object",
       "properties": {
@@ -8612,19 +8508,6 @@
         "description": {
           "type": "string",
           "description": "Rule description.Will be stored with the rule."
-        }
-      }
-    },
-    "WorkflowServiceExecuteMultiOperationBody": {
-      "type": "object",
-      "properties": {
-        "operations": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/ExecuteMultiOperationRequestOperation"
-          },
-          "description": "List of operations to execute within a single workflow.\n\nPreconditions:\n- The list of operations must not be empty.\n- The workflow ids must match across operations.\n- The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.\n\nNote that additional operation-specific restrictions have to be considered."
         }
       }
     },
@@ -12033,19 +11916,6 @@
       "description": "- EVENT_TYPE_UNSPECIFIED: Place holder and should never appear in a Workflow execution history\n - EVENT_TYPE_WORKFLOW_EXECUTION_STARTED: Workflow execution has been triggered/started\nIt contains Workflow execution inputs, as well as Workflow timeout configurations\n - EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED: Workflow execution has successfully completed and contains Workflow execution results\n - EVENT_TYPE_WORKFLOW_EXECUTION_FAILED: Workflow execution has unsuccessfully completed and contains the Workflow execution error\n - EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT: Workflow execution has timed out by the Temporal Server\nUsually due to the Workflow having not been completed within timeout settings\n - EVENT_TYPE_WORKFLOW_TASK_SCHEDULED: Workflow Task has been scheduled and the SDK client should now be able to process any new history events\n - EVENT_TYPE_WORKFLOW_TASK_STARTED: Workflow Task has started and the SDK client has picked up the Workflow Task and is processing new history events\n - EVENT_TYPE_WORKFLOW_TASK_COMPLETED: Workflow Task has completed\nThe SDK client picked up the Workflow Task and processed new history events\nSDK client may or may not ask the Temporal Server to do additional work, such as:\nEVENT_TYPE_ACTIVITY_TASK_SCHEDULED\nEVENT_TYPE_TIMER_STARTED\nEVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES\nEVENT_TYPE_MARKER_RECORDED\nEVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED\nEVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED\nEVENT_TYPE_WORKFLOW_EXECUTION_FAILED\nEVENT_TYPE_WORKFLOW_EXECUTION_CANCELED\nEVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW\n - EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT: Workflow Task encountered a timeout\nEither an SDK client with a local cache was not available at the time, or it took too long for the SDK client to process the task\n - EVENT_TYPE_WORKFLOW_TASK_FAILED: Workflow Task encountered a failure\nUsually this means that the Workflow was non-deterministic\nHowever, the Workflow reset functionality also uses this event\n - EVENT_TYPE_ACTIVITY_TASK_SCHEDULED: Activity Task was scheduled\nThe SDK client should pick up this activity task and execute\nThis event type contains activity inputs, as well as activity timeout configurations\n - EVENT_TYPE_ACTIVITY_TASK_STARTED: Activity Task has started executing\nThe SDK client has picked up the Activity Task and is processing the Activity invocation\n - EVENT_TYPE_ACTIVITY_TASK_COMPLETED: Activity Task has finished successfully\nThe SDK client has picked up and successfully completed the Activity Task\nThis event type contains Activity execution results\n - EVENT_TYPE_ACTIVITY_TASK_FAILED: Activity Task has finished unsuccessfully\nThe SDK picked up the Activity Task but unsuccessfully completed it\nThis event type contains Activity execution errors\n - EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT: Activity has timed out according to the Temporal Server\nActivity did not complete within the timeout settings\n - EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED: A request to cancel the Activity has occurred\nThe SDK client will be able to confirm cancellation of an Activity during an Activity heartbeat\n - EVENT_TYPE_ACTIVITY_TASK_CANCELED: Activity has been cancelled\n - EVENT_TYPE_TIMER_STARTED: A timer has started\n - EVENT_TYPE_TIMER_FIRED: A timer has fired\n - EVENT_TYPE_TIMER_CANCELED: A time has been cancelled\n - EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED: A request has been made to cancel the Workflow execution\n - EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED: SDK client has confirmed the cancellation request and the Workflow execution has been cancelled\n - EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED: Workflow has requested that the Temporal Server try to cancel another Workflow\n - EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED: Temporal Server could not cancel the targeted Workflow\nThis is usually because the target Workflow could not be found\n - EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED: Temporal Server has successfully requested the cancellation of the target Workflow\n - EVENT_TYPE_MARKER_RECORDED: A marker has been recorded.\nThis event type is transparent to the Temporal Server\nThe Server will only store it and will not try to understand it.\n - EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED: Workflow has received a Signal event\nThe event type contains the Signal name, as well as a Signal payload\n - EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED: Workflow execution has been forcefully terminated\nThis is usually because the terminate Workflow API was called\n - EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW: Workflow has successfully completed and a new Workflow has been started within the same transaction\nContains last Workflow execution results as well as new Workflow execution inputs\n - EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED: Temporal Server will try to start a child Workflow\n - EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED: Child Workflow execution cannot be started/triggered\nUsually due to a child Workflow ID collision\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED: Child Workflow execution has successfully started/triggered\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED: Child Workflow execution has successfully completed\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED: Child Workflow execution has unsuccessfully completed\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED: Child Workflow execution has been cancelled\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT: Child Workflow execution has timed out by the Temporal Server\n - EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED: Child Workflow execution has been terminated\n - EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED: Temporal Server will try to Signal the targeted Workflow\nContains the Signal name, as well as a Signal payload\n - EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED: Temporal Server cannot Signal the targeted Workflow\nUsually because the Workflow could not be found\n - EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED: Temporal Server has successfully Signaled the targeted Workflow\n - EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES: Workflow search attributes should be updated and synchronized with the visibility store\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED: An update was admitted. Note that not all admitted updates result in this\nevent. See UpdateAdmittedEventOrigin for situations in which this event\nis created.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED: An update was accepted (i.e. passed validation, perhaps because no validator was defined)\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED: This event is never written to history.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED: An update completed\n - EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED_EXTERNALLY: Some property or properties of the workflow as a whole have changed by non-workflow code.\nThe distinction of external vs. command-based modification is important so the SDK can\nmaintain determinism when using the command-based approach.\n - EVENT_TYPE_ACTIVITY_PROPERTIES_MODIFIED_EXTERNALLY: Some property or properties of an already-scheduled activity have changed by non-workflow code.\nThe distinction of external vs. command-based modification is important so the SDK can\nmaintain determinism when using the command-based approach.\n - EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED: Workflow properties modified by user workflow code\n - EVENT_TYPE_NEXUS_OPERATION_SCHEDULED: A Nexus operation was scheduled using a ScheduleNexusOperation command.\n - EVENT_TYPE_NEXUS_OPERATION_STARTED: An asynchronous Nexus operation was started by a Nexus handler.\n - EVENT_TYPE_NEXUS_OPERATION_COMPLETED: A Nexus operation completed successfully.\n - EVENT_TYPE_NEXUS_OPERATION_FAILED: A Nexus operation failed.\n - EVENT_TYPE_NEXUS_OPERATION_CANCELED: A Nexus operation completed as canceled.\n - EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT: A Nexus operation timed out.\n - EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED: A Nexus operation was requested to be canceled using a RequestCancelNexusOperation command.\n - EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED: Workflow execution options updated by user.\n - EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED: A cancellation request for a Nexus operation was successfully delivered to the Nexus handler.\n - EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED: A cancellation request for a Nexus operation resulted in an error.\n - EVENT_TYPE_WORKFLOW_EXECUTION_PAUSED: An event that indicates that the workflow execution has been paused.\n - EVENT_TYPE_WORKFLOW_EXECUTION_UNPAUSED: An event that indicates that the previously paused workflow execution has been unpaused.",
       "title": "Whenever this list of events is changed do change the function shouldBufferEvent in mutableStateBuilder.go to make sure to do the correct event ordering"
     },
-    "v1ExecuteMultiOperationResponse": {
-      "type": "object",
-      "properties": {
-        "responses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/ExecuteMultiOperationResponseResponse"
-          }
-        }
-      },
-      "description": "IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination (\"Update-with-Start\") when both\n  1. the workflow update for the requested update ID has already completed, and\n  2. the workflow for the requested workflow ID has already been closed,\nthen you'll receive\n  - an update response containing the update's outcome, and\n  - a start response with a `status` field that reflects the workflow's current state."
-    },
     "v1ExternalWorkflowExecutionCancelRequestedEventAttributes": {
       "type": "object",
       "properties": {
@@ -15301,123 +15171,6 @@
         }
       }
     },
-    "v1StartWorkflowExecutionRequest": {
-      "type": "object",
-      "properties": {
-        "namespace": {
-          "type": "string"
-        },
-        "workflowId": {
-          "type": "string"
-        },
-        "workflowType": {
-          "$ref": "#/definitions/v1WorkflowType"
-        },
-        "taskQueue": {
-          "$ref": "#/definitions/v1TaskQueue"
-        },
-        "input": {
-          "$ref": "#/definitions/v1Payloads",
-          "description": "Serialized arguments to the workflow. These are passed as arguments to the workflow function."
-        },
-        "workflowExecutionTimeout": {
-          "type": "string",
-          "description": "Total workflow execution timeout including retries and continue as new."
-        },
-        "workflowRunTimeout": {
-          "type": "string",
-          "description": "Timeout of a single workflow run."
-        },
-        "workflowTaskTimeout": {
-          "type": "string",
-          "description": "Timeout of a single workflow task."
-        },
-        "identity": {
-          "type": "string",
-          "title": "The identity of the client who initiated this request"
-        },
-        "requestId": {
-          "type": "string",
-          "description": "A unique identifier for this start request. Typically UUIDv4."
-        },
-        "workflowIdReusePolicy": {
-          "$ref": "#/definitions/v1WorkflowIdReusePolicy",
-          "description": "Defines whether to allow re-using the workflow id from a previously *closed* workflow.\nThe default policy is WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE.\n\nSee `workflow_id_conflict_policy` for handling a workflow id duplication with a *running* workflow."
-        },
-        "workflowIdConflictPolicy": {
-          "$ref": "#/definitions/v1WorkflowIdConflictPolicy",
-          "description": "Defines how to resolve a workflow id conflict with a *running* workflow.\nThe default policy is WORKFLOW_ID_CONFLICT_POLICY_FAIL.\n\nSee `workflow_id_reuse_policy` for handling a workflow id duplication with a *closed* workflow."
-        },
-        "retryPolicy": {
-          "$ref": "#/definitions/v1RetryPolicy",
-          "description": "The retry policy for the workflow. Will never exceed `workflow_execution_timeout`."
-        },
-        "cronSchedule": {
-          "type": "string",
-          "title": "See https://docs.temporal.io/docs/content/what-is-a-temporal-cron-job/"
-        },
-        "memo": {
-          "$ref": "#/definitions/v1Memo"
-        },
-        "searchAttributes": {
-          "$ref": "#/definitions/v1SearchAttributes"
-        },
-        "header": {
-          "$ref": "#/definitions/v1Header"
-        },
-        "requestEagerExecution": {
-          "type": "boolean",
-          "description": "Request to get the first workflow task inline in the response bypassing matching service and worker polling.\nIf set to `true` the caller is expected to have a worker available and capable of processing the task.\nThe returned task will be marked as started and is expected to be completed by the specified\n`workflow_task_timeout`."
-        },
-        "continuedFailure": {
-          "$ref": "#/definitions/v1Failure",
-          "description": "These values will be available as ContinuedFailure and LastCompletionResult in the\nWorkflowExecutionStarted event and through SDKs. The are currently only used by the\nserver itself (for the schedules feature) and are not intended to be exposed in\nStartWorkflowExecution."
-        },
-        "lastCompletionResult": {
-          "$ref": "#/definitions/v1Payloads"
-        },
-        "workflowStartDelay": {
-          "type": "string",
-          "description": "Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.\nIf the workflow gets a signal before the delay, a workflow task will be dispatched and the rest\nof the delay will be ignored."
-        },
-        "completionCallbacks": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1Callback"
-          },
-          "description": "Callbacks to be called by the server when this workflow reaches a terminal state.\nIf the workflow continues-as-new, these callbacks will be carried over to the new execution.\nCallback addresses must be whitelisted in the server's dynamic configuration."
-        },
-        "userMetadata": {
-          "$ref": "#/definitions/v1UserMetadata",
-          "description": "Metadata on the workflow if it is started. This is carried over to the WorkflowExecutionInfo\nfor use by user interfaces to display the fixed as-of-start summary and details of the\nworkflow."
-        },
-        "links": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/v1Link"
-          },
-          "description": "Links to be associated with the workflow."
-        },
-        "versioningOverride": {
-          "$ref": "#/definitions/v1VersioningOverride",
-          "description": "If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.\nTo unset the override after the workflow is running, use UpdateWorkflowExecutionOptions."
-        },
-        "onConflictOptions": {
-          "$ref": "#/definitions/v1OnConflictOptions",
-          "description": "Defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
-        },
-        "priority": {
-          "$ref": "#/definitions/v1Priority",
-          "title": "Priority metadata"
-        },
-        "eagerWorkerDeploymentOptions": {
-          "$ref": "#/definitions/v1WorkerDeploymentOptions",
-          "description": "Deployment Options of the worker who will process the eager task. Passed when `request_eager_execution=true`."
-        }
-      }
-    },
     "v1StartWorkflowExecutionResponse": {
       "type": "object",
       "properties": {
@@ -16046,31 +15799,6 @@
         "workflowExecutionOptions": {
           "$ref": "#/definitions/v1WorkflowExecutionOptions",
           "description": "Workflow Execution options after update."
-        }
-      }
-    },
-    "v1UpdateWorkflowExecutionRequest": {
-      "type": "object",
-      "properties": {
-        "namespace": {
-          "type": "string",
-          "description": "The namespace name of the target Workflow."
-        },
-        "workflowExecution": {
-          "$ref": "#/definitions/v1WorkflowExecution",
-          "description": "The target Workflow Id and (optionally) a specific Run Id thereof."
-        },
-        "firstExecutionRunId": {
-          "type": "string",
-          "description": "If set, this call will error if the most recent (if no Run Id is set on\n`workflow_execution`), or specified (if it is) Workflow Execution is not\npart of the same execution chain as this Id."
-        },
-        "waitPolicy": {
-          "$ref": "#/definitions/v1WaitPolicy",
-          "description": "Specifies client's intent to wait for Update results.\nNOTE: This field works together with API call timeout which is limited by\nserver timeout (maximum wait time). If server timeout is expired before\nuser specified timeout, API call returns even if specified stage is not reached.\nActual reached stage will be included in the response."
-        },
-        "request": {
-          "$ref": "#/definitions/v1Request",
-          "description": "The request information that will be delivered all the way down to the\nWorkflow Execution."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -3719,6 +3719,222 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/complete": {
+      "post": {
+        "summary": "See `RespondActivityTaskCompleted`. This version allows clients to record completions by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCompletedById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCompletedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to complete",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCompletedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/fail": {
+      "post": {
+        "summary": "See `RecordActivityTaskFailed`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskFailedById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskFailedByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to fail",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskFailedByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/heartbeat": {
+      "post": {
+        "summary": "See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RecordActivityTaskHeartbeatById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RecordActivityTaskHeartbeatByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity we're heartbeating",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRecordActivityTaskHeartbeatByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/resolve-as-canceled": {
+      "post": {
+        "summary": "See `RespondActivityTaskCanceled`. This version allows clients to record failures by\nnamespace/workflow id/activity id instead of task token.",
+        "operationId": "RespondActivityTaskCanceledById4",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RespondActivityTaskCanceledByIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "description": "Namespace of the workflow which scheduled this activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "workflowId",
+            "description": "Id of the workflow which scheduled this activity, leave empty to target a standalone activity",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "activityId",
+            "description": "Id of the activity to confirm is cancelled",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceRespondActivityTaskCanceledByIdBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/workflows/{workflowId}/pause": {
       "post": {
         "summary": "Note: This is an experimental API and the behavior may change in a future release.\nPauseWorkflowExecution pauses the workflow execution specified in the request. Pausing a workflow execution results in\n- The workflow execution status changes to `PAUSED` and a new WORKFLOW_EXECUTION_PAUSED event is added to the history\n- No new workflow tasks or activity tasks are dispatched.\n  - Any workflow task currently executing on the worker will be allowed to complete.\n  - Any activity task currently executing will be paused.\n- All server-side events will continue to be processed by the server.\n- Queries & Updates on a paused workflow will be rejected.",
@@ -8631,7 +8847,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the WorkflowExecutionSignaled event."
         }
@@ -10232,6 +10448,82 @@
       },
       "description": "Keep the parameters in sync with:\n  - temporal.api.batch.v1.BatchOperationUpdateWorkflowExecutionOptions.\n  - temporal.api.workflow.v1.PostResetOperation.UpdateWorkflowOptions."
     },
+    "apiCommonV1Link": {
+      "type": "object",
+      "properties": {
+        "workflowEvent": {
+          "$ref": "#/definitions/LinkWorkflowEvent"
+        },
+        "batchJob": {
+          "$ref": "#/definitions/LinkBatchJob"
+        }
+      },
+      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
+    },
+    "apiFailureV1Failure": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "encodedAttributes": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
+        },
+        "cause": {
+          "$ref": "#/definitions/apiFailureV1Failure"
+        },
+        "applicationFailureInfo": {
+          "$ref": "#/definitions/v1ApplicationFailureInfo"
+        },
+        "timeoutFailureInfo": {
+          "$ref": "#/definitions/v1TimeoutFailureInfo"
+        },
+        "canceledFailureInfo": {
+          "$ref": "#/definitions/v1CanceledFailureInfo"
+        },
+        "terminatedFailureInfo": {
+          "$ref": "#/definitions/v1TerminatedFailureInfo"
+        },
+        "serverFailureInfo": {
+          "$ref": "#/definitions/v1ServerFailureInfo"
+        },
+        "resetWorkflowFailureInfo": {
+          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
+        },
+        "activityFailureInfo": {
+          "$ref": "#/definitions/v1ActivityFailureInfo"
+        },
+        "childWorkflowExecutionFailureInfo": {
+          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
+        },
+        "nexusOperationExecutionFailureInfo": {
+          "$ref": "#/definitions/v1NexusOperationFailureInfo"
+        },
+        "nexusHandlerFailureInfo": {
+          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
+        }
+      }
+    },
+    "apiUpdateV1Request": {
+      "type": "object",
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/v1Meta"
+        },
+        "input": {
+          "$ref": "#/definitions/v1Input"
+        }
+      },
+      "description": "The client request that triggers a Workflow Update."
+    },
     "protobufAny": {
       "type": "object",
       "properties": {
@@ -10346,7 +10638,7 @@
           "description": "Time when the activity transitioned to a closed state."
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Failure details from the last failed attempt."
         },
         "lastWorkerIdentity": {
@@ -10463,7 +10755,7 @@
           "description": "The result if the activity completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "The failure if the activity completed unsuccessfully."
         }
       },
@@ -10653,7 +10945,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "title": "Failure details"
         },
         "scheduledEventId": {
@@ -10755,7 +11047,7 @@
           "title": "Starting at 1, the number of times this task has been attempted"
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Will be set to the most recent failure details, if this task has previously failed and then\nbeen retried."
         },
         "workerVersion": {
@@ -10773,7 +11065,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "If this activity had failed, was retried, and then timed out, that failure is stored as the\n`cause` in here."
         },
         "scheduledEventId": {
@@ -11233,7 +11525,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links associated with the callback. It can be used to link to underlying resources of the\ncallback."
         }
@@ -11270,7 +11562,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -11382,7 +11674,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apiFailureV1Failure"
         },
         "namespace": {
           "type": "string",
@@ -12309,58 +12601,6 @@
       },
       "title": "Represents a historical replication status of a Namespace"
     },
-    "v1Failure": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string",
-          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
-        },
-        "stackTrace": {
-          "type": "string"
-        },
-        "encodedAttributes": {
-          "$ref": "#/definitions/v1Payload",
-          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
-        },
-        "cause": {
-          "$ref": "#/definitions/v1Failure"
-        },
-        "applicationFailureInfo": {
-          "$ref": "#/definitions/v1ApplicationFailureInfo"
-        },
-        "timeoutFailureInfo": {
-          "$ref": "#/definitions/v1TimeoutFailureInfo"
-        },
-        "canceledFailureInfo": {
-          "$ref": "#/definitions/v1CanceledFailureInfo"
-        },
-        "terminatedFailureInfo": {
-          "$ref": "#/definitions/v1TerminatedFailureInfo"
-        },
-        "serverFailureInfo": {
-          "$ref": "#/definitions/v1ServerFailureInfo"
-        },
-        "resetWorkflowFailureInfo": {
-          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
-        },
-        "activityFailureInfo": {
-          "$ref": "#/definitions/v1ActivityFailureInfo"
-        },
-        "childWorkflowExecutionFailureInfo": {
-          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
-        },
-        "nexusOperationExecutionFailureInfo": {
-          "$ref": "#/definitions/v1NexusOperationFailureInfo"
-        },
-        "nexusHandlerFailureInfo": {
-          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
-        }
-      }
-    },
     "v1FetchWorkerConfigResponse": {
       "type": "object",
       "properties": {
@@ -12661,7 +12901,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Link"
+            "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links associated with the event."
         },
@@ -12912,18 +13152,6 @@
       },
       "description": "IntervalSpec matches times that can be expressed as:\nepoch + n * interval + phase\nwhere n is an integer.\nphase defaults to zero if missing. interval is required.\nBoth interval and phase must be non-negative and are truncated to the nearest\nsecond before any calculations.\nFor example, an interval of 1 hour with phase of zero would match every hour,\non the hour. The same interval but a phase of 19 minutes would match every\nxx:19:00. An interval of 28 days with phase zero would match\n2022-02-17T00:00:00Z (among other times). The same interval with a phase of 3\ndays, 5 hours, and 23 minutes would match 2022-02-20T05:23:00Z instead."
     },
-    "v1Link": {
-      "type": "object",
-      "properties": {
-        "workflowEvent": {
-          "$ref": "#/definitions/LinkWorkflowEvent"
-        },
-        "batchJob": {
-          "$ref": "#/definitions/LinkBatchJob"
-        }
-      },
-      "description": "Link can be associated with history events. It might contain information about an external entity\nrelated to the history event. For example, workflow A makes a Nexus call that starts workflow B:\nin this case, a history event in workflow A could contain a Link to the workflow started event in\nworkflow B, and vice-versa."
-    },
     "v1ListActivityExecutionsResponse": {
       "type": "object",
       "properties": {
@@ -13167,7 +13395,7 @@
           "$ref": "#/definitions/v1Header"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Some uses of markers, like a local activity, could \"fail\". If they did that is recorded here."
         }
       }
@@ -13497,7 +13725,7 @@
           "description": "The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported\nwith."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "scheduledEventId": {
@@ -13531,7 +13759,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Cancellation details."
         },
         "requestId": {
@@ -13563,7 +13791,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -13620,7 +13848,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo."
         },
         "requestId": {
@@ -13746,7 +13974,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "requestId": {
@@ -13781,7 +14009,7 @@
           "$ref": "#/definitions/v1Payloads"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apiFailureV1Failure"
         }
       },
       "description": "The outcome of a Workflow Update: success or failure."
@@ -13864,7 +14092,7 @@
           "format": "date-time"
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apiFailureV1Failure"
         },
         "lastWorkerIdentity": {
           "type": "string"
@@ -14002,7 +14230,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -14469,18 +14697,6 @@
       ],
       "default": "REPLICATION_STATE_UNSPECIFIED"
     },
-    "v1Request": {
-      "type": "object",
-      "properties": {
-        "meta": {
-          "$ref": "#/definitions/v1Meta"
-        },
-        "input": {
-          "$ref": "#/definitions/v1Input"
-        }
-      },
-      "description": "The client request that triggers a Workflow Update."
-    },
     "v1RequestCancelActivityExecutionResponse": {
       "type": "object"
     },
@@ -14729,7 +14945,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Failure"
+            "$ref": "#/definitions/apiFailureV1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -14742,7 +14958,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Failure"
+            "$ref": "#/definitions/apiFailureV1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -15525,7 +15741,7 @@
           "description": "When `request_eager_execution` is set on the `StartWorkflowExecutionRequest`, the server - if supported - will\nreturn the first workflow task to be eagerly executed.\nThe caller is expected to have a worker available to process the task."
         },
         "link": {
-          "$ref": "#/definitions/v1Link",
+          "$ref": "#/definitions/apiCommonV1Link",
           "description": "Link to the workflow event."
         }
       }
@@ -16840,7 +17056,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "Deprecated. If a workflow's retry policy would cause a new run to start when the current one\nhas failed, this field would be populated with that failure. Now (when supported by server\nand sdk) the final event will be `WORKFLOW_EXECUTION_FAILED` with `new_execution_run_id` set."
         },
         "lastCompletionResult": {
@@ -16915,7 +17131,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "title": "Serialized result of workflow failure (ex: An exception thrown, or error returned)"
         },
         "retryState": {
@@ -17196,7 +17412,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "continuedFailure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/apiFailureV1Failure"
         },
         "lastCompletionResult": {
           "$ref": "#/definitions/v1Payloads"
@@ -17381,7 +17597,7 @@
           "description": "The event ID used to sequence the original request message."
         },
         "acceptedRequest": {
-          "$ref": "#/definitions/v1Request",
+          "$ref": "#/definitions/apiUpdateV1Request",
           "description": "The message payload of the original request message that initiated this\nupdate."
         }
       }
@@ -17390,7 +17606,7 @@
       "type": "object",
       "properties": {
         "request": {
-          "$ref": "#/definitions/v1Request",
+          "$ref": "#/definitions/apiUpdateV1Request",
           "description": "The update request associated with this event."
         },
         "origin": {
@@ -17434,11 +17650,11 @@
           "description": "The event ID used to sequence the original request message."
         },
         "rejectedRequest": {
-          "$ref": "#/definitions/v1Request",
+          "$ref": "#/definitions/apiUpdateV1Request",
           "description": "The message payload of the original request message that initiated this\nupdate."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "description": "The cause of rejection."
         }
       }
@@ -17770,7 +17986,7 @@
           "$ref": "#/definitions/v1WorkflowTaskFailedCause"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/apiFailureV1Failure",
           "title": "The failure details"
         },
         "identity": {

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -164,308 +164,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/cancel:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RespondActivityTaskFailed is called by workers when processing an activity task fails.
-
-         For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history
-         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
-         no longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: RespondActivityTaskCanceled
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCanceledRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCanceledResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/cancel-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RespondActivityTaskCanceled`. This version allows clients to record failures by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RespondActivityTaskCanceledById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCanceledByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCanceledByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/complete:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RespondActivityTaskCompleted is called by workers when they successfully complete an activity
-         task.
-
-         For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history
-         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
-         no longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: RespondActivityTaskCompleted
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCompletedRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCompletedResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/complete-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RespondActivityTaskCompleted`. This version allows clients to record completions by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RespondActivityTaskCompletedById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCompletedByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCompletedByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/fail:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RespondActivityTaskFailed is called by workers when processing an activity task fails.
-
-         This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and
-         a new workflow task created for the workflow. Fails with `NotFound` if the task token is no
-         longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: RespondActivityTaskFailed
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskFailedRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskFailedResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/fail-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RecordActivityTaskFailed`. This version allows clients to record failures by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RespondActivityTaskFailedById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskFailedByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskFailedByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/heartbeat:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.
-
-         If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,
-         then the current attempt times out. Depending on RetryPolicy, this may trigger a retry or
-         time out the activity.
-
-         For workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow
-         history. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,
-         in that event, the SDK should request cancellation of the activity.
-
-         The request may contain response `details` which will be persisted by the server and may be
-         used by the activity to checkpoint progress. The `cancel_requested` field in the response
-         indicates whether cancellation has been requested for the activity.
-      operationId: RecordActivityTaskHeartbeat
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RecordActivityTaskHeartbeatRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecordActivityTaskHeartbeatResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/heartbeat-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RecordActivityTaskHeartbeatById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/pause:
+  /api/v1/namespaces/{namespace}/activities-deprecated/pause:
     post:
       tags:
         - WorkflowService
@@ -515,7 +214,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/reset:
+  /api/v1/namespaces/{namespace}/activities-deprecated/reset:
     post:
       tags:
         - WorkflowService
@@ -566,7 +265,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/unpause:
+  /api/v1/namespaces/{namespace}/activities-deprecated/unpause:
     post:
       tags:
         - WorkflowService
@@ -613,7 +312,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/activities/update-options:
+  /api/v1/namespaces/{namespace}/activities-deprecated/update-options:
     post:
       tags:
         - WorkflowService
@@ -796,6 +495,135 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activities/{activityId}/complete:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCompleted`. This version allows clients to record completions by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCompletedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to complete
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCompletedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCompletedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activities/{activityId}/fail:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskFailed`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskFailedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to fail
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskFailedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskFailedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activities/{activityId}/heartbeat:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RecordActivityTaskHeartbeatById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity we're heartbeating
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/activities/{activityId}/outcome:
     get:
       tags:
@@ -827,6 +655,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PollActivityExecutionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activities/{activityId}/resolve-as-canceled:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCanceled`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCanceledById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to confirm is cancelled
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCanceledByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCanceledByIdResponse'
         default:
           description: Default error response
           content:
@@ -873,6 +744,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activity-complete:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RespondActivityTaskCompleted is called by workers when they successfully complete an activity
+         task.
+
+         For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history
+         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
+         no longer valid due to activity timeout, already being completed, or never having existed.
+      operationId: RespondActivityTaskCompleted
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCompletedRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCompletedResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/activity-count:
     get:
       tags:
@@ -897,6 +805,122 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CountActivityExecutionsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activity-fail:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RespondActivityTaskFailed is called by workers when processing an activity task fails.
+
+         This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and
+         a new workflow task created for the workflow. Fails with `NotFound` if the task token is no
+         longer valid due to activity timeout, already being completed, or never having existed.
+      operationId: RespondActivityTaskFailed
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskFailedRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskFailedResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activity-heartbeat:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.
+
+         If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,
+         then the current attempt times out. Depending on RetryPolicy, this may trigger a retry or
+         time out the activity.
+
+         For workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow
+         history. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,
+         in that event, the SDK should request cancellation of the activity.
+
+         The request may contain response `details` which will be persisted by the server and may be
+         used by the activity to checkpoint progress. The `cancel_requested` field in the response
+         indicates whether cancellation has been requested for the activity.
+      operationId: RecordActivityTaskHeartbeat
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordActivityTaskHeartbeatRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordActivityTaskHeartbeatResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/activity-resolve-as-canceled:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RespondActivityTaskFailed is called by workers when processing an activity task fails.
+
+         For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history
+         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
+         no longer valid due to activity timeout, already being completed, or never having existed.
+      operationId: RespondActivityTaskCanceled
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCanceledRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCanceledResponse'
         default:
           description: Default error response
           content:
@@ -3050,6 +3074,248 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/complete:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCompleted`. This version allows clients to record completions by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCompletedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to complete
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCompletedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCompletedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/fail:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskFailed`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskFailedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to fail
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskFailedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskFailedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/heartbeat:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RecordActivityTaskHeartbeatById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity we're heartbeating
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/resolve-as-canceled:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCanceled`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCanceledById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to confirm is cancelled
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCanceledByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCanceledByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/pause:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        Note: This is an experimental API and the behavior may change in a future release.
+         PauseWorkflowExecution pauses the workflow execution specified in the request. Pausing a workflow execution results in
+         - The workflow execution status changes to `PAUSED` and a new WORKFLOW_EXECUTION_PAUSED event is added to the history
+         - No new workflow tasks or activity tasks are dispatched.
+           - Any workflow task currently executing on the worker will be allowed to complete.
+           - Any activity task currently executing will be paused.
+         - All server-side events will continue to be processed by the server.
+         - Queries & Updates on a paused workflow will be rejected.
+      operationId: PauseWorkflowExecution
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow to pause.
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: ID of the workflow execution to be paused. Required.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PauseWorkflowExecutionRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PauseWorkflowExecutionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/workflows/{workflowId}/signal-with-start/{signalName}:
     post:
       tags:
@@ -3918,308 +4184,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/cancel:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RespondActivityTaskFailed is called by workers when processing an activity task fails.
-
-         For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history
-         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
-         no longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: RespondActivityTaskCanceled
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCanceledRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCanceledResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/cancel-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RespondActivityTaskCanceled`. This version allows clients to record failures by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RespondActivityTaskCanceledById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCanceledByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCanceledByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/complete:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RespondActivityTaskCompleted is called by workers when they successfully complete an activity
-         task.
-
-         For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history
-         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
-         no longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: RespondActivityTaskCompleted
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCompletedRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCompletedResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/complete-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RespondActivityTaskCompleted`. This version allows clients to record completions by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RespondActivityTaskCompletedById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskCompletedByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskCompletedByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/fail:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RespondActivityTaskFailed is called by workers when processing an activity task fails.
-
-         This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and
-         a new workflow task created for the workflow. Fails with `NotFound` if the task token is no
-         longer valid due to activity timeout, already being completed, or never having existed.
-      operationId: RespondActivityTaskFailed
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskFailedRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskFailedResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/fail-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RecordActivityTaskFailed`. This version allows clients to record failures by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RespondActivityTaskFailedById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RespondActivityTaskFailedByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RespondActivityTaskFailedByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/heartbeat:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.
-
-         If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,
-         then the current attempt times out. Depending on RetryPolicy, this may trigger a retry or
-         time out the activity.
-
-         For workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow
-         history. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,
-         in that event, the SDK should request cancellation of the activity.
-
-         The request may contain response `details` which will be persisted by the server and may be
-         used by the activity to checkpoint progress. The `cancel_requested` field in the response
-         indicates whether cancellation has been requested for the activity.
-      operationId: RecordActivityTaskHeartbeat
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RecordActivityTaskHeartbeatRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecordActivityTaskHeartbeatResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/heartbeat-by-id:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by
-         namespace/workflow id/activity id instead of task token.
-
-         (-- api-linter: core::0136::prepositions=disabled
-             aip.dev/not-precedent: "By" is used to indicate request type. --)
-      operationId: RecordActivityTaskHeartbeatById
-      parameters:
-        - name: namespace
-          in: path
-          description: Namespace of the workflow which scheduled this activity
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/pause:
+  /namespaces/{namespace}/activities-deprecated/pause:
     post:
       tags:
         - WorkflowService
@@ -4269,7 +4234,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/reset:
+  /namespaces/{namespace}/activities-deprecated/reset:
     post:
       tags:
         - WorkflowService
@@ -4320,7 +4285,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/unpause:
+  /namespaces/{namespace}/activities-deprecated/unpause:
     post:
       tags:
         - WorkflowService
@@ -4367,7 +4332,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/activities/update-options:
+  /namespaces/{namespace}/activities-deprecated/update-options:
     post:
       tags:
         - WorkflowService
@@ -4550,6 +4515,135 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activities/{activityId}/complete:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCompleted`. This version allows clients to record completions by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCompletedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to complete
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCompletedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCompletedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activities/{activityId}/fail:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskFailed`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskFailedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to fail
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskFailedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskFailedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activities/{activityId}/heartbeat:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RecordActivityTaskHeartbeatById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity we're heartbeating
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/activities/{activityId}/outcome:
     get:
       tags:
@@ -4581,6 +4675,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PollActivityExecutionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activities/{activityId}/resolve-as-canceled:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCanceled`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCanceledById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to confirm is cancelled
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCanceledByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCanceledByIdResponse'
         default:
           description: Default error response
           content:
@@ -4627,6 +4764,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activity-complete:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RespondActivityTaskCompleted is called by workers when they successfully complete an activity
+         task.
+
+         For workflow activities, this results in a new `ACTIVITY_TASK_COMPLETED` event being written to the workflow history
+         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
+         no longer valid due to activity timeout, already being completed, or never having existed.
+      operationId: RespondActivityTaskCompleted
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCompletedRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCompletedResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/activity-count:
     get:
       tags:
@@ -4651,6 +4825,122 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CountActivityExecutionsResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activity-fail:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RespondActivityTaskFailed is called by workers when processing an activity task fails.
+
+         This results in a new `ACTIVITY_TASK_FAILED` event being written to the workflow history and
+         a new workflow task created for the workflow. Fails with `NotFound` if the task token is no
+         longer valid due to activity timeout, already being completed, or never having existed.
+      operationId: RespondActivityTaskFailed
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskFailedRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskFailedResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activity-heartbeat:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RecordActivityTaskHeartbeat is optionally called by workers while they execute activities.
+
+         If a worker fails to heartbeat within the `heartbeat_timeout` interval for the activity task,
+         then the current attempt times out. Depending on RetryPolicy, this may trigger a retry or
+         time out the activity.
+
+         For workflow activities, an `ACTIVITY_TASK_TIMED_OUT` event will be written to the workflow
+         history. Calling `RecordActivityTaskHeartbeat` will fail with `NotFound` in such situations,
+         in that event, the SDK should request cancellation of the activity.
+
+         The request may contain response `details` which will be persisted by the server and may be
+         used by the activity to checkpoint progress. The `cancel_requested` field in the response
+         indicates whether cancellation has been requested for the activity.
+      operationId: RecordActivityTaskHeartbeat
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordActivityTaskHeartbeatRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordActivityTaskHeartbeatResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/activity-resolve-as-canceled:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        RespondActivityTaskFailed is called by workers when processing an activity task fails.
+
+         For workflow activities, this results in a new `ACTIVITY_TASK_CANCELED` event being written to the workflow history
+         and a new workflow task created for the workflow. Fails with `NotFound` if the task token is
+         no longer valid due to activity timeout, already being completed, or never having existed.
+      operationId: RespondActivityTaskCanceled
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCanceledRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCanceledResponse'
         default:
           description: Default error response
           content:
@@ -6740,6 +7030,202 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StartWorkflowExecutionResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/complete:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCompleted`. This version allows clients to record completions by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCompletedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to complete
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCompletedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCompletedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/fail:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskFailed`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskFailedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to fail
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskFailedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskFailedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/heartbeat:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RecordActivityTaskHeartbeatById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity we're heartbeating
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/resolve-as-canceled:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCanceled`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCanceledById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to confirm is cancelled
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCanceledByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCanceledByIdResponse'
         default:
           description: Default error response
           content:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -3074,6 +3074,202 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/complete:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCompleted`. This version allows clients to record completions by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCompletedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to complete
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCompletedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCompletedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/fail:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskFailed`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskFailedById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to fail
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskFailedByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskFailedByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/heartbeat:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RecordActivityTaskHeartbeat`. This version allows clients to record heartbeats by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RecordActivityTaskHeartbeatById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity we're heartbeating
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordActivityTaskHeartbeatByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{workflowId}/activities/{activityId}/resolve-as-canceled:
+    post:
+      tags:
+        - WorkflowService
+      description: |-
+        See `RespondActivityTaskCanceled`. This version allows clients to record failures by
+         namespace/workflow id/activity id instead of task token.
+
+         (-- api-linter: core::0136::prepositions=disabled
+             aip.dev/not-precedent: "By" is used to indicate request type. --)
+      operationId: RespondActivityTaskCanceledById
+      parameters:
+        - name: namespace
+          in: path
+          description: Namespace of the workflow which scheduled this activity
+          required: true
+          schema:
+            type: string
+        - name: workflowId
+          in: path
+          description: Id of the workflow which scheduled this activity, leave empty to target a standalone activity
+          required: true
+          schema:
+            type: string
+        - name: activityId
+          in: path
+          description: Id of the activity to confirm is cancelled
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RespondActivityTaskCanceledByIdRequest'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RespondActivityTaskCanceledByIdResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/workflows/{workflowId}/pause:
     post:
       tags:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -2763,46 +2763,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /api/v1/namespaces/{namespace}/workflows/execute-multi-operation:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        ExecuteMultiOperation executes multiple operations within a single workflow.
-
-         Operations are started atomically, meaning if *any* operation fails to be started, none are,
-         and the request fails. Upon start, the API returns only when *all* operations have a response.
-
-         Upon failure, it returns `MultiOperationExecutionFailure` where the status code
-         equals the status code of the *first* operation that failed to be started.
-
-         NOTE: Experimental API.
-      operationId: ExecuteMultiOperation
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ExecuteMultiOperationRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ExecuteMultiOperationResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}:
     get:
       tags:
@@ -6499,46 +6459,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-  /namespaces/{namespace}/workflows/execute-multi-operation:
-    post:
-      tags:
-        - WorkflowService
-      description: |-
-        ExecuteMultiOperation executes multiple operations within a single workflow.
-
-         Operations are started atomically, meaning if *any* operation fails to be started, none are,
-         and the request fails. Upon start, the API returns only when *all* operations have a response.
-
-         Upon failure, it returns `MultiOperationExecutionFailure` where the status code
-         equals the status code of the *first* operation that failed to be started.
-
-         NOTE: Experimental API.
-      operationId: ExecuteMultiOperation
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ExecuteMultiOperationRequest'
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ExecuteMultiOperationResponse'
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/workflows/{execution.workflow_id}:
     get:
       tags:
@@ -9196,63 +9116,6 @@ components:
           type: string
           description: Nexus task queue to route requests to.
       description: Target a worker polling on a Nexus task queue in a specific namespace.
-    ExecuteMultiOperationRequest:
-      type: object
-      properties:
-        namespace:
-          type: string
-        operations:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExecuteMultiOperationRequest_Operation'
-          description: |-
-            List of operations to execute within a single workflow.
-
-             Preconditions:
-             - The list of operations must not be empty.
-             - The workflow ids must match across operations.
-             - The only valid list of operations at this time is [StartWorkflow, UpdateWorkflow], in this order.
-
-             Note that additional operation-specific restrictions have to be considered.
-    ExecuteMultiOperationRequest_Operation:
-      type: object
-      properties:
-        startWorkflow:
-          allOf:
-            - $ref: '#/components/schemas/StartWorkflowExecutionRequest'
-          description: |-
-            Additional restrictions:
-             - setting `cron_schedule` is invalid
-             - setting `request_eager_execution` is invalid
-             - setting `workflow_start_delay` is invalid
-        updateWorkflow:
-          allOf:
-            - $ref: '#/components/schemas/UpdateWorkflowExecutionRequest'
-          description: |-
-            Additional restrictions:
-             - setting `first_execution_run_id` is invalid
-             - setting `workflow_execution.run_id` is invalid
-    ExecuteMultiOperationResponse:
-      type: object
-      properties:
-        responses:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExecuteMultiOperationResponse_Response'
-      description: |-
-        IMPORTANT: For [StartWorkflow, UpdateWorkflow] combination ("Update-with-Start") when both
-           1. the workflow update for the requested update ID has already completed, and
-           2. the workflow for the requested workflow ID has already been closed,
-         then you'll receive
-           - an update response containing the update's outcome, and
-           - a start response with a `status` field that reflects the workflow's current state.
-    ExecuteMultiOperationResponse_Response:
-      type: object
-      properties:
-        startWorkflow:
-          $ref: '#/components/schemas/StartWorkflowExecutionResponse'
-        updateWorkflow:
-          $ref: '#/components/schemas/UpdateWorkflowExecutionResponse'
     ExternalWorkflowExecutionCancelRequestedEventAttributes:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -111,16 +111,9 @@ service WorkflowService {
     // Upon failure, it returns `MultiOperationExecutionFailure` where the status code
     // equals the status code of the *first* operation that failed to be started.
     //
-    // NOTE: Experimental API.
+    // (-- api-linter: core::0127::http-annotation=disabled
+    //     aip.dev/not-precedent: To be exposed over HTTP in the future. --)
     rpc ExecuteMultiOperation (ExecuteMultiOperationRequest) returns (ExecuteMultiOperationResponse) {
-        option (google.api.http) = {
-            post: "/namespaces/{namespace}/workflows/execute-multi-operation"
-            body: "*"
-            additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/workflows/execute-multi-operation"
-                body: "*"
-            }
-        };
     }
 
     // GetWorkflowExecutionHistory returns the history of specified workflow execution. Fails with

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -211,10 +211,10 @@ service WorkflowService {
     // indicates whether cancellation has been requested for the activity.
     rpc RecordActivityTaskHeartbeat (RecordActivityTaskHeartbeatRequest) returns (RecordActivityTaskHeartbeatResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/heartbeat"
+            post: "/namespaces/{namespace}/activity-heartbeat"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/heartbeat"
+                post: "/api/v1/namespaces/{namespace}/activity-heartbeat"
                 body: "*"
             }
         };
@@ -227,10 +227,21 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RecordActivityTaskHeartbeatById (RecordActivityTaskHeartbeatByIdRequest) returns (RecordActivityTaskHeartbeatByIdResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/heartbeat-by-id"
+            // Standalone
+            post: "/namespaces/{namespace}/activities/{activity_id}/heartbeat"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/heartbeat-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/{activity_id}/heartbeat"
+                body: "*"
+            }
+
+            // Workflow
+            additional_bindings {
+                post: "/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/heartbeat"
+                body: "*"
+            }
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/heartbeat"
                 body: "*"
             }
         };
@@ -244,10 +255,10 @@ service WorkflowService {
     // no longer valid due to activity timeout, already being completed, or never having existed.
     rpc RespondActivityTaskCompleted (RespondActivityTaskCompletedRequest) returns (RespondActivityTaskCompletedResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/complete"
+            post: "/namespaces/{namespace}/activity-complete"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/complete"
+                post: "/api/v1/namespaces/{namespace}/activity-complete"
                 body: "*"
             }
         };
@@ -260,10 +271,21 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskCompletedById (RespondActivityTaskCompletedByIdRequest) returns (RespondActivityTaskCompletedByIdResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/complete-by-id"
+            // Standalone
+            post: "/namespaces/{namespace}/activities/{activity_id}/complete"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/complete-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/{activity_id}/complete"
+                body: "*"
+            }
+
+            // Workflow
+            additional_bindings {
+                post: "/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/complete"
+                body: "*"
+            }
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/complete"
                 body: "*"
             }
         };
@@ -276,10 +298,10 @@ service WorkflowService {
     // longer valid due to activity timeout, already being completed, or never having existed.
     rpc RespondActivityTaskFailed (RespondActivityTaskFailedRequest) returns (RespondActivityTaskFailedResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/fail"
+            post: "/namespaces/{namespace}/activity-fail"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/fail"
+                post: "/api/v1/namespaces/{namespace}/activity-fail"
                 body: "*"
             }
         };
@@ -292,10 +314,21 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskFailedById (RespondActivityTaskFailedByIdRequest) returns (RespondActivityTaskFailedByIdResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/fail-by-id"
+            // Standalone
+            post: "/namespaces/{namespace}/activities/{activity_id}/fail"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/fail-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/{activity_id}/fail"
+                body: "*"
+            }
+
+            // Workflow
+            additional_bindings {
+                post: "/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/fail"
+                body: "*"
+            }
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/fail"
                 body: "*"
             }
         };
@@ -308,10 +341,10 @@ service WorkflowService {
     // no longer valid due to activity timeout, already being completed, or never having existed.
     rpc RespondActivityTaskCanceled (RespondActivityTaskCanceledRequest) returns (RespondActivityTaskCanceledResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/cancel"
+            post: "/namespaces/{namespace}/activity-resolve-as-canceled"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/cancel"
+                post: "/api/v1/namespaces/{namespace}/activity-resolve-as-canceled"
                 body: "*"
             }
         };
@@ -324,10 +357,21 @@ service WorkflowService {
     //     aip.dev/not-precedent: "By" is used to indicate request type. --)
     rpc RespondActivityTaskCanceledById (RespondActivityTaskCanceledByIdRequest) returns (RespondActivityTaskCanceledByIdResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/cancel-by-id"
+            // Standalone
+            post: "/namespaces/{namespace}/activities/{activity_id}/resolve-as-canceled"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/cancel-by-id"
+                post: "/api/v1/namespaces/{namespace}/activities/{activity_id}/resolve-as-canceled"
+                body: "*"
+            }
+
+            // Workflow
+            additional_bindings {
+                post: "/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/resolve-as-canceled"
+                body: "*"
+            }
+            additional_bindings {
+                post: "/api/v1/namespaces/{namespace}/workflows/{workflow_id}/activities/{activity_id}/resolve-as-canceled"
                 body: "*"
             }
         };
@@ -1028,10 +1072,10 @@ service WorkflowService {
     // structured to work well for standalone activities.
     rpc UpdateActivityOptions (UpdateActivityOptionsRequest) returns (UpdateActivityOptionsResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/update-options"
+            post: "/namespaces/{namespace}/activities-deprecated/update-options"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/update-options"
+                post: "/api/v1/namespaces/{namespace}/activities-deprecated/update-options"
                 body: "*"
             }
         };
@@ -1069,10 +1113,10 @@ service WorkflowService {
     // structured to work well for standalone activities.
     rpc PauseActivity (PauseActivityRequest) returns (PauseActivityResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/pause"
+            post: "/namespaces/{namespace}/activities-deprecated/pause"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/pause"
+                post: "/api/v1/namespaces/{namespace}/activities-deprecated/pause"
                 body: "*"
             }
         };
@@ -1095,10 +1139,10 @@ service WorkflowService {
     // structured to work well for standalone activities.
     rpc UnpauseActivity (UnpauseActivityRequest) returns (UnpauseActivityResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/unpause"
+            post: "/namespaces/{namespace}/activities-deprecated/unpause"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/unpause"
+                post: "/api/v1/namespaces/{namespace}/activities-deprecated/unpause"
                 body: "*"
             }
         };
@@ -1125,10 +1169,10 @@ service WorkflowService {
     // structured to work well for standalone activities.
     rpc ResetActivity (ResetActivityRequest) returns (ResetActivityResponse) {
         option (google.api.http) = {
-            post: "/namespaces/{namespace}/activities/reset"
+            post: "/namespaces/{namespace}/activities-deprecated/reset"
             body: "*"
             additional_bindings {
-                post: "/api/v1/namespaces/{namespace}/activities/reset"
+                post: "/api/v1/namespaces/{namespace}/activities-deprecated/reset"
                 body: "*"
             }
         };


### PR DESCRIPTION
**What changed?**
Includes two commits for patching the `v1.61.0` release with a fix for clashing API routes when standalone activities were introduced to the server.
1. 7d69897e0c2b1c5bec0deb0af101875a314fbf69 #717 
2. ff1426537c60035562bc4fa68c795f0a2d1dc439 #718

**Why?**
This version is broken in the UI

**Breaking changes**
No

**Server PR**
NA