### PR TITLE
add time-skipping config in WorkflowExecutionStartedEventAttributes

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -18625,6 +18625,10 @@
         "declinedTargetVersionUpgrade": {
           "$ref": "#/definitions/v1DeclinedTargetVersionUpgrade",
           "description": "During a previous run of this workflow, the server may have notified the SDK\nthat the Target Worker Deployment Version changed, but the SDK declined to\nupgrade (e.g., by continuing-as-new with PINNED behavior). This field records\nthe target version that was declined.\n\nThis is a wrapper message to distinguish \"never declined\" (nil wrapper) from\n\"declined an unversioned target\" (non-nil wrapper with nil deployment_version).\n\nUsed internally by the server during continue-as-new and retry.\nShould not be read or interpreted by SDKs."
+        },
+        "timeSkippingConfig": {
+          "$ref": "#/definitions/v1TimeSkippingConfig",
+          "description": "Initial time-skipping configuration for this workflow execution, recorded at start time.\nThis may have been set explicitly via the start workflow request, or propagated from a\nparent/previous execution.\n\nThe configuration may be updated after start via UpdateWorkflowExecutionOptions, which\nwill be reflected in the WorkflowExecutionOptionsUpdatedEvent."
         }
       },
       "title": "Always the first event in workflow history"

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -17355,6 +17355,16 @@ components:
 
              Used internally by the server during continue-as-new and retry.
              Should not be read or interpreted by SDKs.
+        timeSkippingConfig:
+          allOf:
+            - $ref: '#/components/schemas/TimeSkippingConfig'
+          description: |-
+            Initial time-skipping configuration for this workflow execution, recorded at start time.
+             This may have been set explicitly via the start workflow request, or propagated from a
+             parent/previous execution.
+
+             The configuration may be updated after start via UpdateWorkflowExecutionOptions, which
+             will be reflected in the WorkflowExecutionOptionsUpdatedEvent.
       description: Always the first event in workflow history
     WorkflowExecutionTerminatedEventAttributes:
       type: object

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -196,6 +196,14 @@ message WorkflowExecutionStartedEventAttributes {
     // Used internally by the server during continue-as-new and retry.
     // Should not be read or interpreted by SDKs.
     DeclinedTargetVersionUpgrade declined_target_version_upgrade = 40;
+
+    // Initial time-skipping configuration for this workflow execution, recorded at start time.
+    // This may have been set explicitly via the start workflow request, or propagated from a
+    // parent/previous execution.
+    //
+    // The configuration may be updated after start via UpdateWorkflowExecutionOptions, which
+    // will be reflected in the WorkflowExecutionOptionsUpdatedEvent.
+    temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 41;
 }
 
 // Wrapper for a target deployment version that the SDK declined to upgrade to.


### PR DESCRIPTION
**What changed?**
add time-skipping config (optional field) in WorkflowExecutionStartedEventAttributes 

**Why?**
there won't be a way to show it to users and support workflow rebuilt