### PR TITLE
Add link field to propagate backlink in signal and signal-with-start responses

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16546,11 +16546,21 @@
         "started": {
           "type": "boolean",
           "description": "If true, a new workflow was started."
+        },
+        "signalLink": {
+          "$ref": "#/definitions/v1Link",
+          "description": "Link to be associated with the WorkflowExecutionSignaled event.\nAdded on the response to propagate the backlink.\nAvailable from Temporal server 1.31 and up."
         }
       }
     },
     "v1SignalWorkflowExecutionResponse": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "link": {
+          "$ref": "#/definitions/v1Link",
+          "description": "Link to be associated with the WorkflowExecutionSignaled event.\nAdded on the response to propagate the backlink.\nAvailable from Temporal server 1.31 and up."
+        }
+      }
     },
     "v1StartActivityExecutionResponse": {
       "type": "object",
@@ -18470,6 +18480,10 @@
         "externalWorkflowExecution": {
           "$ref": "#/definitions/v1WorkflowExecution",
           "description": "When signal origin is a workflow execution, this field is set."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "The request ID of the Signal request, used by the server to attach this to\nthe correct Event ID when generating link."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -14167,6 +14167,13 @@ components:
         started:
           type: boolean
           description: If true, a new workflow was started.
+        signalLink:
+          allOf:
+            - $ref: '#/components/schemas/Link'
+          description: |-
+            Link to be associated with the WorkflowExecutionSignaled event.
+             Added on the response to propagate the backlink.
+             Available from Temporal server 1.31 and up.
     SignalWorkflowExecutionRequest:
       type: object
       properties:
@@ -14207,7 +14214,14 @@ components:
            - temporal.api.workflow.v1.PostResetOperation.SignalWorkflow.
     SignalWorkflowExecutionResponse:
       type: object
-      properties: {}
+      properties:
+        link:
+          allOf:
+            - $ref: '#/components/schemas/Link'
+          description: |-
+            Link to be associated with the WorkflowExecutionSignaled event.
+             Added on the response to propagate the backlink.
+             Available from Temporal server 1.31 and up.
     StartActivityExecutionRequest:
       type: object
       properties:
@@ -17118,6 +17132,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/WorkflowExecution'
           description: When signal origin is a workflow execution, this field is set.
+        requestId:
+          type: string
+          description: |-
+            The request ID of the Signal request, used by the server to attach this to
+             the correct Event ID when generating link.
     WorkflowExecutionStartedEventAttributes:
       type: object
       properties:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -612,6 +612,9 @@ message WorkflowExecutionSignaledEventAttributes {
     bool skip_generate_workflow_task = 5 [deprecated = true];
     // When signal origin is a workflow execution, this field is set.
     temporal.api.common.v1.WorkflowExecution external_workflow_execution = 6;
+    // The request ID of the Signal request, used by the server to attach this to
+    // the correct Event ID when generating link.
+    string request_id = 7;
 }
 
 message WorkflowExecutionTerminatedEventAttributes {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -793,6 +793,10 @@ message SignalWorkflowExecutionRequest {
 }
 
 message SignalWorkflowExecutionResponse {
+    // Link to be associated with the WorkflowExecutionSignaled event.
+    // Added on the response to propagate the backlink.
+    // Available from Temporal server 1.31 and up.
+    temporal.api.common.v1.Link link = 1;
 }
 
 message SignalWithStartWorkflowExecutionRequest {
@@ -865,6 +869,10 @@ message SignalWithStartWorkflowExecutionResponse {
     string run_id = 1;
     // If true, a new workflow was started.
     bool started = 2;
+    // Link to be associated with the WorkflowExecutionSignaled event.
+    // Added on the response to propagate the backlink.
+    // Available from Temporal server 1.31 and up.
+    temporal.api.common.v1.Link signal_link = 3;
 }
 
 message ResetWorkflowExecutionRequest {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added `link` fields on `SignalWorkflowExecutionResponse` and `SignalWithStartWorkflowExecutionRequest`. I think a singular link should suffice but if reviewers feel otherwise (especially w.r.t. `SignalWithStartWorkflowExecutionRequest`) let me know.

<!-- Tell your future self why have you made these changes -->
**Why?**

To propagate backlinks on signal and signal-with-start executions back to the caller.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

Not a breaking change (unused field)


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**

https://github.com/temporalio/temporal/pull/9897
