### PR TITLE
Add revision_number to DeclinedTargetVersionUpgrade

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12725,6 +12725,11 @@
       "properties": {
         "deploymentVersion": {
           "$ref": "#/definitions/v1WorkerDeploymentVersion"
+        },
+        "revisionNumber": {
+          "type": "string",
+          "format": "int64",
+          "description": "Revision number of the task queue routing config at the time the target\nwas declined. If an incoming target's revision is <= this value, it is\nnot newer and is not used for deciding whether or not to suppress the\nupgrade signal."
         }
       },
       "description": "Wrapper for a target deployment version that the SDK declined to upgrade to.\nSee declined_target_version_upgrade on WorkflowExecutionStartedEventAttributes."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9762,6 +9762,13 @@ components:
       properties:
         deploymentVersion:
           $ref: '#/components/schemas/WorkerDeploymentVersion'
+        revisionNumber:
+          type: string
+          description: |-
+            Revision number of the task queue routing config at the time the target
+             was declined. If an incoming target's revision is <= this value, it is
+             not newer and is not used for deciding whether or not to suppress the
+             upgrade signal.
       description: |-
         Wrapper for a target deployment version that the SDK declined to upgrade to.
          See declined_target_version_upgrade on WorkflowExecutionStartedEventAttributes.

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -202,6 +202,11 @@ message WorkflowExecutionStartedEventAttributes {
 // See declined_target_version_upgrade on WorkflowExecutionStartedEventAttributes.
 message DeclinedTargetVersionUpgrade {
     temporal.api.deployment.v1.WorkerDeploymentVersion deployment_version = 1;
+    // Revision number of the task queue routing config at the time the target
+    // was declined. If an incoming target's revision is <= this value, it is
+    // not newer and is not used for deciding whether or not to suppress the
+    // upgrade signal.
+    int64 revision_number = 2;
 }
 
 message WorkflowExecutionCompletedEventAttributes {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
- Added `revision_number` to `DeclinedTargetVersionUpgrade`, which already took in a deployment version.
- Recap about what `DeclinedTargetVersionUpgrade` does: the main intention of this field was to "remember" which target version we have rejected when a pinned workflow declines to AU when CAN'ing. However, you could have matching partitions send you back stale target deployment versions, and we don't want to "bounce back" and CAN our pinned workflows when they see such a stale version. For that very purpose, we resort to now store the revision number here.


<!-- Tell your future self why have you made these changes -->
- I explained it above


<!-- Are there any breaking changes on binary or code level? -->
- None, changes are additive.
- Also, no changes required from the SDK perspective


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
https://github.com/temporalio/temporal/pull/9895
