### PR TITLE
add on conflict options for standalone activities

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10468,7 +10468,7 @@
           "description": "Links to be associated with the activity. Callbacks may also have associated links;\nlinks already included with a callback should not be duplicated here."
         },
         "onConflictOptions": {
-          "$ref": "#/definitions/apiActivityV1OnConflictOptions",
+          "$ref": "#/definitions/apiCommonV1OnConflictOptions",
           "description": "Options for handling conflicts when using ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING."
         }
       }
@@ -11139,24 +11139,6 @@
         }
       }
     },
-    "apiActivityV1OnConflictOptions": {
-      "type": "object",
-      "properties": {
-        "attachRequestId": {
-          "type": "boolean",
-          "description": "Attaches the request ID to the running activity."
-        },
-        "attachCompletionCallbacks": {
-          "type": "boolean",
-          "description": "Attaches the completion callbacks to the running activity."
-        },
-        "attachLinks": {
-          "type": "boolean",
-          "description": "Attaches the links to the running activity."
-        }
-      },
-      "description": "When StartActivityExecution uses the conflict policy ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING and\nthere is already an existing running activity, OnConflictOptions defines actions to be taken on\nthe existing running activity."
-    },
     "apiCallbackV1CallbackInfo": {
       "type": "object",
       "properties": {
@@ -11198,6 +11180,24 @@
         }
       },
       "description": "Common callback information. Specific CallbackInfo messages should embed this and may include additional fields."
+    },
+    "apiCommonV1OnConflictOptions": {
+      "type": "object",
+      "properties": {
+        "attachRequestId": {
+          "type": "boolean",
+          "description": "Attaches the request ID to the running execution."
+        },
+        "attachCompletionCallbacks": {
+          "type": "boolean",
+          "description": "Attaches the completion callbacks to the running execution."
+        },
+        "attachLinks": {
+          "type": "boolean",
+          "description": "Attaches the links to the running execution."
+        }
+      },
+      "description": "When starting an execution with a conflict policy that uses an existing execution and there is already an existing\nrunning execution, OnConflictOptions defines actions to be taken on the existing running execution."
     },
     "apiWorkflowV1CallbackInfo": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10464,6 +10464,10 @@
             "$ref": "#/definitions/apiCommonV1Link"
           },
           "description": "Links to be associated with the activity. Callbacks may also have associated links;\nlinks already included with a callback should not be duplicated here."
+        },
+        "onConflictOptions": {
+          "$ref": "#/definitions/apiActivityV1OnConflictOptions",
+          "description": "Options for handling conflicts when using ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING."
         }
       }
     },
@@ -10618,7 +10622,7 @@
           "description": "If set, takes precedence over the Versioning Behavior sent by the SDK on Workflow Task completion.\nTo unset the override after the workflow is running, use UpdateWorkflowExecutionOptions."
         },
         "onConflictOptions": {
-          "$ref": "#/definitions/v1OnConflictOptions",
+          "$ref": "#/definitions/apiWorkflowV1OnConflictOptions",
           "description": "Defines actions to be done to the existing running workflow when the conflict policy\nWORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING is used. If not set (ie., nil value) or set to a\nempty object (ie., all options with default value), it won't do anything to the existing\nrunning workflow. If set, it will add a history event to the running workflow."
         },
         "priority": {
@@ -11133,6 +11137,24 @@
         }
       }
     },
+    "apiActivityV1OnConflictOptions": {
+      "type": "object",
+      "properties": {
+        "attachRequestId": {
+          "type": "boolean",
+          "description": "Attaches the request ID to the running activity."
+        },
+        "attachCompletionCallbacks": {
+          "type": "boolean",
+          "description": "Attaches the completion callbacks to the running activity."
+        },
+        "attachLinks": {
+          "type": "boolean",
+          "description": "Attaches the links to the running activity."
+        }
+      },
+      "description": "When StartActivityExecution uses the conflict policy ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING and\nthere is already an existing running activity, OnConflictOptions defines actions to be taken on\nthe existing running activity."
+    },
     "apiCallbackV1CallbackInfo": {
       "type": "object",
       "properties": {
@@ -11227,6 +11249,24 @@
           "$ref": "#/definitions/CallbackInfoWorkflowClosed"
         }
       }
+    },
+    "apiWorkflowV1OnConflictOptions": {
+      "type": "object",
+      "properties": {
+        "attachRequestId": {
+          "type": "boolean",
+          "description": "Attaches the request ID to the running workflow."
+        },
+        "attachCompletionCallbacks": {
+          "type": "boolean",
+          "description": "Attaches the completion callbacks to the running workflow."
+        },
+        "attachLinks": {
+          "type": "boolean",
+          "description": "Attaches the links to the WorkflowExecutionOptionsUpdatedEvent history event."
+        }
+      },
+      "description": "When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and\nthere is already an existing running workflow, OnConflictOptions defines actions to be taken on\nthe existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent\nhistory event in the running workflow with the changes requested in this object."
     },
     "protobufAny": {
       "type": "object",
@@ -14923,24 +14963,6 @@
         }
       },
       "description": "Nexus operation timed out."
-    },
-    "v1OnConflictOptions": {
-      "type": "object",
-      "properties": {
-        "attachRequestId": {
-          "type": "boolean",
-          "description": "Attaches the request ID to the running workflow."
-        },
-        "attachCompletionCallbacks": {
-          "type": "boolean",
-          "description": "Attaches the completion callbacks to the running workflow."
-        },
-        "attachLinks": {
-          "type": "boolean",
-          "description": "Attaches the links to the WorkflowExecutionOptionsUpdatedEvent history event."
-        }
-      },
-      "description": "When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and\nthere is already an existing running workflow, OnConflictOptions defines actions to be taken on\nthe existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent\nhistory event in the running workflow with the changes requested in this object."
     },
     "v1Outcome": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11726,17 +11726,16 @@ components:
       properties:
         attachRequestId:
           type: boolean
-          description: Attaches the request ID to the running activity.
+          description: Attaches the request ID to the running execution.
         attachCompletionCallbacks:
           type: boolean
-          description: Attaches the completion callbacks to the running activity.
+          description: Attaches the completion callbacks to the running execution.
         attachLinks:
           type: boolean
-          description: Attaches the links to the running activity.
+          description: Attaches the links to the running execution.
       description: |-
-        When StartActivityExecution uses the conflict policy ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING and
-         there is already an existing running activity, OnConflictOptions defines actions to be taken on
-         the existing running activity.
+        When starting an execution with a conflict policy that uses an existing execution and there is already an existing
+         running execution, OnConflictOptions defines actions to be taken on the existing running execution.
     Outcome:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11724,18 +11724,17 @@ components:
       properties:
         attachRequestId:
           type: boolean
-          description: Attaches the request ID to the running workflow.
+          description: Attaches the request ID to the running activity.
         attachCompletionCallbacks:
           type: boolean
-          description: Attaches the completion callbacks to the running workflow.
+          description: Attaches the completion callbacks to the running activity.
         attachLinks:
           type: boolean
-          description: Attaches the links to the WorkflowExecutionOptionsUpdatedEvent history event.
+          description: Attaches the links to the running activity.
       description: |-
-        When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and
-         there is already an existing running workflow, OnConflictOptions defines actions to be taken on
-         the existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent
-         history event in the running workflow with the changes requested in this object.
+        When StartActivityExecution uses the conflict policy ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING and
+         there is already an existing running activity, OnConflictOptions defines actions to be taken on
+         the existing running activity.
     Outcome:
       type: object
       properties:
@@ -14323,6 +14322,10 @@ components:
           description: |-
             Links to be associated with the activity. Callbacks may also have associated links;
              links already included with a callback should not be duplicated here.
+        onConflictOptions:
+          allOf:
+            - $ref: '#/components/schemas/OnConflictOptions'
+          description: Options for handling conflicts when using ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
     StartActivityExecutionResponse:
       type: object
       properties:

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -200,18 +200,6 @@ message ActivityExecutionListInfo {
     google.protobuf.Duration execution_duration = 11;
 }
 
-// When StartActivityExecution uses the conflict policy ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING and
-// there is already an existing running activity, OnConflictOptions defines actions to be taken on
-// the existing running activity.
-message OnConflictOptions {
-    // Attaches the request ID to the running activity.
-    bool attach_request_id = 1;
-    // Attaches the completion callbacks to the running activity.
-    bool attach_completion_callbacks = 2;
-    // Attaches the links to the running activity.
-    bool attach_links = 3;
-}
-
 // CallbackInfo contains the state of an attached activity callback.
 message CallbackInfo {
     // Trigger for when the activity is closed.

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -200,6 +200,18 @@ message ActivityExecutionListInfo {
     google.protobuf.Duration execution_duration = 11;
 }
 
+// When StartActivityExecution uses the conflict policy ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING and
+// there is already an existing running activity, OnConflictOptions defines actions to be taken on
+// the existing running activity.
+message OnConflictOptions {
+    // Attaches the request ID to the running activity.
+    bool attach_request_id = 1;
+    // Attaches the completion callbacks to the running activity.
+    bool attach_completion_callbacks = 2;
+    // Attaches the links to the running activity.
+    bool attach_links = 3;
+}
+
 // CallbackInfo contains the state of an attached activity callback.
 message CallbackInfo {
     // Trigger for when the activity is closed.

--- a/temporal/api/common/v1/message.proto
+++ b/temporal/api/common/v1/message.proto
@@ -363,3 +363,14 @@ message WorkerSelector {
         string worker_instance_key = 1;
     }
 }
+
+// When starting an execution with a conflict policy that uses an existing execution and there is already an existing
+// running execution, OnConflictOptions defines actions to be taken on the existing running execution.
+message OnConflictOptions {
+    // Attaches the request ID to the running execution.
+    bool attach_request_id = 1;
+    // Attaches the completion callbacks to the running execution.
+    bool attach_completion_callbacks = 2;
+    // Attaches the links to the running execution.
+    bool attach_links = 3;
+}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2937,6 +2937,8 @@ message StartActivityExecutionRequest {
     // Links to be associated with the activity. Callbacks may also have associated links;
     // links already included with a callback should not be duplicated here.
     repeated temporal.api.common.v1.Link links = 20;
+    // Options for handling conflicts when using ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
+    temporal.api.activity.v1.OnConflictOptions on_conflict_options = 21;
 }
 
 message StartActivityExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2938,7 +2938,7 @@ message StartActivityExecutionRequest {
     // links already included with a callback should not be duplicated here.
     repeated temporal.api.common.v1.Link links = 20;
     // Options for handling conflicts when using ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
-    temporal.api.activity.v1.OnConflictOptions on_conflict_options = 21;
+    temporal.api.common.v1.OnConflictOptions on_conflict_options = 21;
 }
 
 message StartActivityExecutionResponse {


### PR DESCRIPTION
**What changed?**
Added a new OnConflictOptions message to temporal.api.activity.v1 and a corresponding on_conflict_options field to StartActivityExecutionRequest.

**Why?**
When StartActivityExecution uses ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING and a matching activity is already running, the caller needs a way to specify what should be attached to the existing activity (request ID, completion callbacks, links). This mirrors the existing OnConflictOptions for workflows (temporal.api.workflow.v1.OnConflictOptions on StartWorkflowExecutionRequest) but is specific to the activity  domain. 

