### PR TITLE
add heartbeat count to ActivityExecutionInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11443,6 +11443,11 @@
             "$ref": "#/definitions/v1Link"
           },
           "description": "Links to related entities, such as the entity that started this activity."
+        },
+        "totalHeartbeatCount": {
+          "type": "string",
+          "format": "int64",
+          "description": "Total number of heartbeats recorded across all attempts of this activity, including retries."
         }
       },
       "description": "Information about a standalone activity."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8243,6 +8243,9 @@ components:
           items:
             $ref: '#/components/schemas/Link'
           description: Links to related entities, such as the entity that started this activity.
+        totalHeartbeatCount:
+          type: string
+          description: Total number of heartbeats recorded across all attempts of this activity, including retries.
       description: Information about a standalone activity.
     ActivityExecutionListInfo:
       type: object

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -165,6 +165,9 @@ message ActivityExecutionInfo {
 
     // Links to related entities, such as the entity that started this activity.
     repeated temporal.api.common.v1.Link links = 33;
+
+    // Total number of heartbeats recorded across all attempts of this activity, including retries.
+    int64 total_heartbeat_count = 34;
 }
 
 // Limited activity information returned in the list response.


### PR DESCRIPTION
**What changed?**
Added total_heartbeat_count field (int64) to ActivityExecutionInfo

**Why?**
There was no way to see how many heartbeats an activity recorded across its entire lifetime, including retries. This field provides that cumulative count.
