### PR TITLE
Feat/heartbeat count

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11443,6 +11443,11 @@
             "$ref": "#/definitions/v1Link"
           },
           "description": "Links to related entities, such as the entity that started this activity."
+        },
+        "totalHeartbeatCount": {
+          "type": "string",
+          "format": "int64",
+          "description": "Total number of heartbeats recorded across all attempts of this activity, including retries."
         }
       },
       "description": "Information about a standalone activity."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -8243,6 +8243,9 @@ components:
           items:
             $ref: '#/components/schemas/Link'
           description: Links to related entities, such as the entity that started this activity.
+        totalHeartbeatCount:
+          type: string
+          description: Total number of heartbeats recorded across all attempts of this activity, including retries.
       description: Information about a standalone activity.
     ActivityExecutionListInfo:
       type: object

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -165,6 +165,9 @@ message ActivityExecutionInfo {
 
     // Links to related entities, such as the entity that started this activity.
     repeated temporal.api.common.v1.Link links = 33;
+
+    // Total number of heartbeats recorded across all attempts of this activity, including retries.
+    int64 total_heartbeat_count = 34;
 }
 
 // Limited activity information returned in the list response.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This adds a field for counting the total number of heartbeats given to an activity, as received by the server (as an aside, this may be less than the client activity.RecordHeartbeat() calls due to the client's throttling of this call. 

For this change, I'm just commandeering the work already done by @fretz12.

<!-- Tell your future self why have you made these changes -->
**Why?**

This is to provide this information about the total number of heartbeats in the DescribeActivity API call / CLi invocation.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**

Should be backwards compatible. 

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
Should be backwards compatible. 