### PR TITLE
api changes for time-skipping propagation

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -17968,7 +17968,7 @@
         },
         "timeSkippingConfig": {
           "$ref": "#/definitions/v1TimeSkippingConfig",
-          "description": "The propagated time-skipping config for the child workflow."
+          "description": "The propagated time-skipping configuration for the child workflow."
         }
       }
     },
@@ -18372,7 +18372,7 @@
           "description": "If this execution was started by a previous execution that had already skipped some time,\nit inherits the accumulated skipped duration from that execution through this field.\nThis field is set internally by the server and cannot be configured by the user."
         }
       },
-      "description": "Configuration for time skipping during a workflow execution.\nWhen enabled, virtual time advances automatically whenever there is no in-flight work.\nIn-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\nand possibly other features added in the future.\nUser timers are not classified as in-flight work and will be skipped over.\nWhen time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n\nPropagation behavior of time skipping:\nThe enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n(1) Child workflows and continue-as-new: both the configuration and accumulated skipped duration are inherited\n    from the current execution. The configured bound is shared across both the inherited skipped duration\n    and any additional duration skipped by the new run.\n(2) Retry and cron: both the configuration and accumulated skipped duration are inherited as recorded in the\n    StartWorkflowExecutionEvent of the current workflow and the accummulated skipped duration \n    of the current run won't be passed.\n(3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n    all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n    point, the resulting run ends up with the same final time-skipping configuration as the previous run."
+      "description": "Configuration for time skipping during a workflow execution.\nWhen enabled, virtual time advances automatically whenever there is no in-flight work.\nIn-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\nand possibly other features added in the future.\nUser timers are not classified as in-flight work and will be skipped over.\nWhen time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n\nPropagation behavior of time skipping:\nThe enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n(1) Child workflows and continue-as-new: both the configuration and the accumulated skipped duration are\n    inherited from the current execution. The configured bound is shared between the inherited skipped\n    duration and any additional duration skipped by the new run.\n(2) Retry and cron: the configuration and accumulated skipped duration are inherited as recorded when the\n    current workflow started; the accumulated skipped duration of the current run is not propagated.\n(3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n    all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n    point, the resulting run ends up with the same final time-skipping configuration as the previous run."
     },
     "v1TimeoutFailureInfo": {
       "type": "object",
@@ -19656,7 +19656,7 @@
         },
         "timeSkippingConfig": {
           "$ref": "#/definitions/v1TimeSkippingConfig",
-          "description": "Time-skipping configuration for this workflow execution.\nIf not set, the time-skipping conf will not get updated upon request, \ni.e. the existing time-skipping conf will be preserved."
+          "description": "Time-skipping configuration for this workflow execution.\nIf not set, the time-skipping configuration is not updated by this request;\nthe existing configuration is preserved."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -18359,10 +18359,6 @@
           "type": "boolean",
           "description": "Enables or disables time skipping for this workflow execution."
         },
-        "propagatedSkippedDuration": {
-          "type": "string",
-          "description": "If this execution was started by a previous execution that already skipped some time,\nit inherits the virtual time through the propagated skipped duration."
-        },
         "maxSkippedDuration": {
           "type": "string",
           "description": "Maximum total virtual time that can be skipped."
@@ -18371,13 +18367,12 @@
           "type": "string",
           "description": "Maximum elapsed time since time skipping was enabled.\nThis includes both skipped time and real time elapsing."
         },
-        "maxTargetTime": {
+        "initialSkippedDuration": {
           "type": "string",
-          "format": "date-time",
-          "description": "Absolute virtual timestamp at which time skipping is disabled.\nTime skipping will not advance beyond this point."
+          "description": "If this execution was started by a previous execution that had already skipped some time,\nit inherits the accumulated skipped duration from that execution through this field.\nThis field is set internally by the server and cannot be configured by the user."
         }
       },
-      "description": "Configuration for time skipping during a workflow execution.\nWhen enabled, virtual time advances automatically whenever there is no in-flight work.\nIn-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\nand possibly other features added in the future.\nUser timers are not classified as in-flight work and will be skipped over.\nWhen time advances, it skips to the earlier of the next user timer or the configured bound, if either exists."
+      "description": "Configuration for time skipping during a workflow execution.\nWhen enabled, virtual time advances automatically whenever there is no in-flight work.\nIn-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\nand possibly other features added in the future.\nUser timers are not classified as in-flight work and will be skipped over.\nWhen time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n\nPropagation behavior of time skipping:\nThe enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n(1) Child workflows and continue-as-new: both the configuration and accumulated skipped duration are inherited\n    from the current execution. The configured bound is shared across both the inherited skipped duration\n    and any additional duration skipped by the new run.\n(2) Retry and cron: both the configuration and accumulated skipped duration are inherited as recorded in the\n    StartWorkflowExecutionEvent of the current workflow and the accummulated skipped duration \n    of the current run won't be passed.\n(3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n    all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n    point, the resulting run ends up with the same final time-skipping configuration as the previous run."
     },
     "v1TimeoutFailureInfo": {
       "type": "object",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -17965,6 +17965,10 @@
         "priority": {
           "$ref": "#/definitions/v1Priority",
           "title": "Priority metadata"
+        },
+        "timeSkippingConfig": {
+          "$ref": "#/definitions/v1TimeSkippingConfig",
+          "description": "The propagated time-skipping config for the child workflow."
         }
       }
     },
@@ -18353,11 +18357,11 @@
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Enables or disables time skipping for this workflow execution.\nBy default, this field is propagated to transitively related workflows (child workflows/start-as-new/reset) \nat the time they are started.\nChanges made after a transitively related workflow has started are not propagated."
+          "description": "Enables or disables time skipping for this workflow execution."
         },
-        "disablePropagation": {
-          "type": "boolean",
-          "description": "If set, the enabled field is not propagated to transitively related workflows."
+        "propagatedSkippedDuration": {
+          "type": "string",
+          "description": "If this execution was started by a previous execution that already skipped some time,\nit inherits the virtual time through the propagated skipped duration."
         },
         "maxSkippedDuration": {
           "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11446,6 +11446,10 @@
         "timeSkippingConfig": {
           "$ref": "#/definitions/v1TimeSkippingConfig",
           "description": "Time-skipping configuration. If not set, time skipping is disabled."
+        },
+        "initialSkippedDuration": {
+          "type": "string",
+          "description": "If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new) \nthat has already skipped some time, the accumulated skipped duration from that execution \ncan be passed to the new workflow execution through this field."
         }
       }
     },
@@ -17969,6 +17973,10 @@
         "timeSkippingConfig": {
           "$ref": "#/definitions/v1TimeSkippingConfig",
           "description": "The propagated time-skipping configuration for the child workflow."
+        },
+        "initialSkippedDuration": {
+          "type": "string",
+          "description": "Propagate the duration skipped to the child workflow."
         }
       }
     },
@@ -18366,10 +18374,6 @@
         "maxElapsedDuration": {
           "type": "string",
           "description": "Maximum elapsed time since time skipping was enabled.\nThis includes both skipped time and real time elapsing."
-        },
-        "initialSkippedDuration": {
-          "type": "string",
-          "description": "If this execution was started by a previous execution that had already skipped some time,\nit inherits the accumulated skipped duration from that execution through this field.\nThis field is set internally by the server and cannot be configured by the user."
         }
       },
       "description": "Configuration for time skipping during a workflow execution.\nWhen enabled, virtual time advances automatically whenever there is no in-flight work.\nIn-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\nand possibly other features added in the future.\nUser timers are not classified as in-flight work and will be skipped over.\nWhen time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n\nPropagation behavior of time skipping:\nThe enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n(1) Child workflows and continue-as-new: both the configuration and the accumulated skipped duration are\n    inherited from the current execution. The configured bound is shared between the inherited skipped\n    duration and any additional duration skipped by the new run.\n(2) Retry and cron: the configuration and accumulated skipped duration are inherited as recorded when the\n    current workflow started; the accumulated skipped duration of the current run is not propagated.\n(3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n    all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n    point, the resulting run ends up with the same final time-skipping configuration as the previous run."
@@ -19926,6 +19930,10 @@
         "timeSkippingConfig": {
           "$ref": "#/definitions/v1TimeSkippingConfig",
           "description": "Initial time-skipping configuration for this workflow execution, recorded at start time.\nThis may have been set explicitly via the start workflow request, or propagated from a\nparent/previous execution.\n\nThe configuration may be updated after start via UpdateWorkflowExecutionOptions, which\nwill be reflected in the WorkflowExecutionOptionsUpdatedEvent."
+        },
+        "initialSkippedDuration": {
+          "type": "string",
+          "description": "The time skipped by the previous execution that started this workflow.\nIt can happen in cases of child workflows and continue-as-new workflows."
         }
       },
       "title": "Always the first event in workflow history"

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11446,10 +11446,6 @@
         "timeSkippingConfig": {
           "$ref": "#/definitions/v1TimeSkippingConfig",
           "description": "Time-skipping configuration. If not set, time skipping is disabled."
-        },
-        "initialSkippedDuration": {
-          "type": "string",
-          "description": "If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new) \nthat has already skipped some time, the accumulated skipped duration from that execution \ncan be passed to the new workflow execution through this field."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15560,7 +15560,7 @@ components:
         timeSkippingConfig:
           allOf:
             - $ref: '#/components/schemas/TimeSkippingConfig'
-          description: The propagated time-skipping config for the child workflow.
+          description: The propagated time-skipping configuration for the child workflow.
     StartNexusOperationExecutionRequest:
       type: object
       properties:
@@ -16265,7 +16265,7 @@ components:
             If this execution was started by a previous execution that had already skipped some time,
              it inherits the accumulated skipped duration from that execution through this field.
              This field is set internally by the server and cannot be configured by the user.
-      description: "Configuration for time skipping during a workflow execution.\n When enabled, virtual time advances automatically whenever there is no in-flight work.\n In-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\n and possibly other features added in the future.\n User timers are not classified as in-flight work and will be skipped over.\n When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n \n Propagation behavior of time skipping:\n The enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n (1) Child workflows and continue-as-new: both the configuration and accumulated skipped duration are inherited\n     from the current execution. The configured bound is shared across both the inherited skipped duration\n     and any additional duration skipped by the new run.\n (2) Retry and cron: both the configuration and accumulated skipped duration are inherited as recorded in the\n     StartWorkflowExecutionEvent of the current workflow and the accummulated skipped duration \n     of the current run won't be passed.\n (3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n     point, the resulting run ends up with the same final time-skipping configuration as the previous run."
+      description: "Configuration for time skipping during a workflow execution.\n When enabled, virtual time advances automatically whenever there is no in-flight work.\n In-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\n and possibly other features added in the future.\n User timers are not classified as in-flight work and will be skipped over.\n When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n \n Propagation behavior of time skipping:\n The enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n (1) Child workflows and continue-as-new: both the configuration and the accumulated skipped duration are\n     inherited from the current execution. The configured bound is shared between the inherited skipped\n     duration and any additional duration skipped by the new run.\n (2) Retry and cron: the configuration and accumulated skipped duration are inherited as recorded when the\n     current workflow started; the accumulated skipped duration of the current run is not propagated.\n (3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n     point, the resulting run ends up with the same final time-skipping configuration as the previous run."
     TimeoutFailureInfo:
       type: object
       properties:
@@ -18215,7 +18215,10 @@ components:
         timeSkippingConfig:
           allOf:
             - $ref: '#/components/schemas/TimeSkippingConfig'
-          description: "Time-skipping configuration for this workflow execution.\n If not set, the time-skipping conf will not get updated upon request, \n i.e. the existing time-skipping conf will be preserved."
+          description: |-
+            Time-skipping configuration for this workflow execution.
+             If not set, the time-skipping configuration is not updated by this request;
+             the existing configuration is preserved.
     WorkflowExecutionOptionsUpdatedEventAttributes:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15561,6 +15561,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/TimeSkippingConfig'
           description: The propagated time-skipping configuration for the child workflow.
+        initialSkippedDuration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: Propagate the duration skipped to the child workflow.
     StartNexusOperationExecutionRequest:
       type: object
       properties:
@@ -15814,6 +15818,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/TimeSkippingConfig'
           description: Time-skipping configuration. If not set, time skipping is disabled.
+        initialSkippedDuration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: "If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new) \n that has already skipped some time, the accumulated skipped duration from that execution \n can be passed to the new workflow execution through this field."
     StartWorkflowExecutionResponse:
       type: object
       properties:
@@ -16258,13 +16266,6 @@ components:
           description: |-
             Maximum elapsed time since time skipping was enabled.
              This includes both skipped time and real time elapsing.
-        initialSkippedDuration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-          description: |-
-            If this execution was started by a previous execution that had already skipped some time,
-             it inherits the accumulated skipped duration from that execution through this field.
-             This field is set internally by the server and cannot be configured by the user.
       description: "Configuration for time skipping during a workflow execution.\n When enabled, virtual time advances automatically whenever there is no in-flight work.\n In-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\n and possibly other features added in the future.\n User timers are not classified as in-flight work and will be skipped over.\n When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n \n Propagation behavior of time skipping:\n The enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n (1) Child workflows and continue-as-new: both the configuration and the accumulated skipped duration are\n     inherited from the current execution. The configured bound is shared between the inherited skipped\n     duration and any additional duration skipped by the new run.\n (2) Retry and cron: the configuration and accumulated skipped duration are inherited as recorded when the\n     current workflow started; the accumulated skipped duration of the current run is not propagated.\n (3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n     point, the resulting run ends up with the same final time-skipping configuration as the previous run."
     TimeoutFailureInfo:
       type: object
@@ -18562,6 +18563,12 @@ components:
 
              The configuration may be updated after start via UpdateWorkflowExecutionOptions, which
              will be reflected in the WorkflowExecutionOptionsUpdatedEvent.
+        initialSkippedDuration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            The time skipped by the previous execution that started this workflow.
+             It can happen in cases of child workflows and continue-as-new workflows.
       description: Always the first event in workflow history
     WorkflowExecutionTerminatedEventAttributes:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15818,10 +15818,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/TimeSkippingConfig'
           description: Time-skipping configuration. If not set, time skipping is disabled.
-        initialSkippedDuration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-          description: "If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new) \n that has already skipped some time, the accumulated skipped duration from that execution \n can be passed to the new workflow execution through this field."
     StartWorkflowExecutionResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15557,6 +15557,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/Priority'
           description: Priority metadata
+        timeSkippingConfig:
+          allOf:
+            - $ref: '#/components/schemas/TimeSkippingConfig'
+          description: The propagated time-skipping config for the child workflow.
     StartNexusOperationExecutionRequest:
       type: object
       properties:
@@ -16243,10 +16247,13 @@ components:
       properties:
         enabled:
           type: boolean
-          description: "Enables or disables time skipping for this workflow execution.\n By default, this field is propagated to transitively related workflows (child workflows/start-as-new/reset) \n at the time they are started.\n Changes made after a transitively related workflow has started are not propagated."
-        disablePropagation:
-          type: boolean
-          description: If set, the enabled field is not propagated to transitively related workflows.
+          description: Enables or disables time skipping for this workflow execution.
+        propagatedSkippedDuration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            If this execution was started by a previous execution that already skipped some time,
+             it inherits the virtual time through the propagated skipped duration.
         maxSkippedDuration:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16248,12 +16248,6 @@ components:
         enabled:
           type: boolean
           description: Enables or disables time skipping for this workflow execution.
-        propagatedSkippedDuration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-          description: |-
-            If this execution was started by a previous execution that already skipped some time,
-             it inherits the virtual time through the propagated skipped duration.
         maxSkippedDuration:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
@@ -16264,19 +16258,14 @@ components:
           description: |-
             Maximum elapsed time since time skipping was enabled.
              This includes both skipped time and real time elapsing.
-        maxTargetTime:
+        initialSkippedDuration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: |-
-            Absolute virtual timestamp at which time skipping is disabled.
-             Time skipping will not advance beyond this point.
-          format: date-time
-      description: |-
-        Configuration for time skipping during a workflow execution.
-         When enabled, virtual time advances automatically whenever there is no in-flight work.
-         In-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,
-         and possibly other features added in the future.
-         User timers are not classified as in-flight work and will be skipped over.
-         When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.
+            If this execution was started by a previous execution that had already skipped some time,
+             it inherits the accumulated skipped duration from that execution through this field.
+             This field is set internally by the server and cannot be configured by the user.
+      description: "Configuration for time skipping during a workflow execution.\n When enabled, virtual time advances automatically whenever there is no in-flight work.\n In-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\n and possibly other features added in the future.\n User timers are not classified as in-flight work and will be skipped over.\n When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n \n Propagation behavior of time skipping:\n The enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n (1) Child workflows and continue-as-new: both the configuration and accumulated skipped duration are inherited\n     from the current execution. The configured bound is shared across both the inherited skipped duration\n     and any additional duration skipped by the new run.\n (2) Retry and cron: both the configuration and accumulated skipped duration are inherited as recorded in the\n     StartWorkflowExecutionEvent of the current workflow and the accummulated skipped duration \n     of the current run won't be passed.\n (3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n     point, the resulting run ends up with the same final time-skipping configuration as the previous run."
     TimeoutFailureInfo:
       type: object
       properties:

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -204,6 +204,10 @@ message WorkflowExecutionStartedEventAttributes {
     // The configuration may be updated after start via UpdateWorkflowExecutionOptions, which
     // will be reflected in the WorkflowExecutionOptionsUpdatedEvent.
     temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 41;
+
+    // The time skipped by the previous execution that started this workflow.
+    // It can happen in cases of child workflows and continue-as-new workflows.
+    google.protobuf.Duration initial_skipped_duration = 42;
 }
 
 // Wrapper for a target deployment version that the SDK declined to upgrade to.
@@ -773,6 +777,9 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
 
     // The propagated time-skipping configuration for the child workflow.
     temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 21;
+
+    // Propagate the duration skipped to the child workflow.
+    google.protobuf.Duration initial_skipped_duration = 30;
 }
 
 message StartChildWorkflowExecutionFailedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -770,6 +770,9 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     bool inherit_build_id = 19 [deprecated = true];
     // Priority metadata
     temporal.api.common.v1.Priority priority = 20;
+
+    // The propagated time-skipping config for the child workflow.
+    temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 21;
 }
 
 message StartChildWorkflowExecutionFailedEventAttributes {

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -771,7 +771,7 @@ message StartChildWorkflowExecutionInitiatedEventAttributes {
     // Priority metadata
     temporal.api.common.v1.Priority priority = 20;
 
-    // The propagated time-skipping config for the child workflow.
+    // The propagated time-skipping configuration for the child workflow.
     temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 21;
 }
 

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -625,11 +625,6 @@ message TimeSkippingConfig {
         // (-- api-linter: core::0142::time-field-names=disabled --)
         google.protobuf.Duration max_elapsed_duration = 5;
     }
-
-    // If this execution was started by a previous execution that had already skipped some time,
-    // it inherits the accumulated skipped duration from that execution through this field.
-    // This field is set internally by the server and cannot be configured by the user.
-    google.protobuf.Duration initial_skipped_duration = 3;
 }
 
 // Used to override the versioning behavior (and pinned deployment version, if applicable) of a

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -603,6 +603,9 @@ message WorkflowExecutionOptions {
 //     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that
 //     point, the resulting run ends up with the same final time-skipping configuration as the previous run.
 message TimeSkippingConfig {
+    reserved 2, 6;
+    reserved "disable_propagation", "max_target_time";
+
     // Enables or disables time skipping for this workflow execution.
     bool enabled = 1;
 
@@ -615,12 +618,12 @@ message TimeSkippingConfig {
     // signals, updates, or other external events while timers are in progress.
     oneof bound {
         // Maximum total virtual time that can be skipped.
-        google.protobuf.Duration max_skipped_duration = 2;
+        google.protobuf.Duration max_skipped_duration = 4;
 
         // Maximum elapsed time since time skipping was enabled.
         // This includes both skipped time and real time elapsing.
         // (-- api-linter: core::0142::time-field-names=disabled --)
-        google.protobuf.Duration max_elapsed_duration = 3;
+        google.protobuf.Duration max_elapsed_duration = 5;
     }
 }
 

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -591,31 +591,33 @@ message WorkflowExecutionOptions {
 // and possibly other features added in the future.
 // User timers are not classified as in-flight work and will be skipped over.
 // When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.
+// 
+// Propagation behavior of time skipping:
+// The enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:
+// (1) Child workflows and continue-as-new: both the configuration and accumulated skipped duration are inherited
+//     from the current execution. The configured bound is shared across both the inherited skipped duration
+//     and any additional duration skipped by the new run.
+// (2) Retry and cron: both the configuration and accumulated skipped duration are inherited as recorded in the
+//     StartWorkflowExecutionEvent of the current workflow and the accummulated skipped duration 
+//     of the current run won't be passed.
+// (3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays
+//     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that
+//     point, the resulting run ends up with the same final time-skipping configuration as the previous run.
 message TimeSkippingConfig {
-    reserved 2;
-    reserved "disable_propagation";
+    reserved 2, 6;
+    reserved "disable_propagation", "max_target_time";
 
     // Enables or disables time skipping for this workflow execution.
     bool enabled = 1;
 
-    // If this execution was started by a previous execution that already skipped some time,
-    // it inherits the virtual time through the propagated skipped duration.
-    google.protobuf.Duration propagated_skipped_duration = 3;
-
-    // Optional bound that limits how far virtual time can advance while time skipping is active.
+    // Optional bound that limits the gap between the virtual time of this execution and wall-clock time.
     // Once the bound is reached, time skipping is automatically disabled,
-    // but can be re-enabled via UpdateWorkflowExecutionOptions.
+    // but can be re-enabled by setting `enabled` to true via UpdateWorkflowExecutionOptions.
+    // This bound cannot be set to a value smaller than the current skipped duration of the current execution.
     //
     // This is useful in testing scenarios where a workflow is expected to receive
     // signals, updates, or other external events while timers are in progress.
-    //
-    // Bound scope:
-    // - Each bound is independent for each workflow execution.
-    //   When a bound is propagated to a child workflow, the child's bound is only applied to that child execution.
-    // - Continue-as-new is an exception: continued workflow executions are treated as extensions of the
-    //   original execution, so the bound is shared across all executions in the chain.
     oneof bound {
-
         // Maximum total virtual time that can be skipped.
         google.protobuf.Duration max_skipped_duration = 4;
 
@@ -623,11 +625,12 @@ message TimeSkippingConfig {
         // This includes both skipped time and real time elapsing.
         // (-- api-linter: core::0142::time-field-names=disabled --)
         google.protobuf.Duration max_elapsed_duration = 5;
-
-        // Absolute virtual timestamp at which time skipping is disabled.
-        // Time skipping will not advance beyond this point.
-        google.protobuf.Timestamp max_target_time = 6;
     }
+
+    // If this execution was started by a previous execution that had already skipped some time,
+    // it inherits the accumulated skipped duration from that execution through this field.
+    // This field is set internally by the server and cannot be configured by the user.
+    google.protobuf.Duration initial_skipped_duration = 3;
 }
 
 // Used to override the versioning behavior (and pinned deployment version, if applicable) of a

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -580,8 +580,8 @@ message WorkflowExecutionOptions {
     temporal.api.common.v1.Priority priority = 2;
 
     // Time-skipping configuration for this workflow execution.
-    // If not set, the time-skipping conf will not get updated upon request, 
-    // i.e. the existing time-skipping conf will be preserved.
+    // If not set, the time-skipping configuration is not updated by this request;
+    // the existing configuration is preserved.
     TimeSkippingConfig time_skipping_config = 3;
 }
 
@@ -594,12 +594,11 @@ message WorkflowExecutionOptions {
 // 
 // Propagation behavior of time skipping:
 // The enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:
-// (1) Child workflows and continue-as-new: both the configuration and accumulated skipped duration are inherited
-//     from the current execution. The configured bound is shared across both the inherited skipped duration
-//     and any additional duration skipped by the new run.
-// (2) Retry and cron: both the configuration and accumulated skipped duration are inherited as recorded in the
-//     StartWorkflowExecutionEvent of the current workflow and the accummulated skipped duration 
-//     of the current run won't be passed.
+// (1) Child workflows and continue-as-new: both the configuration and the accumulated skipped duration are
+//     inherited from the current execution. The configured bound is shared between the inherited skipped
+//     duration and any additional duration skipped by the new run.
+// (2) Retry and cron: the configuration and accumulated skipped duration are inherited as recorded when the
+//     current workflow started; the accumulated skipped duration of the current run is not propagated.
 // (3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays
 //     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that
 //     point, the resulting run ends up with the same final time-skipping configuration as the previous run.
@@ -613,7 +612,7 @@ message TimeSkippingConfig {
     // Optional bound that limits the gap between the virtual time of this execution and wall-clock time.
     // Once the bound is reached, time skipping is automatically disabled,
     // but can be re-enabled by setting `enabled` to true via UpdateWorkflowExecutionOptions.
-    // This bound cannot be set to a value smaller than the current skipped duration of the current execution.
+    // This bound cannot be set to a value smaller than the execution's currently skipped duration.
     //
     // This is useful in testing scenarios where a workflow is expected to receive
     // signals, updates, or other external events while timers are in progress.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -603,9 +603,6 @@ message WorkflowExecutionOptions {
 //     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that
 //     point, the resulting run ends up with the same final time-skipping configuration as the previous run.
 message TimeSkippingConfig {
-    reserved 2, 6;
-    reserved "disable_propagation", "max_target_time";
-
     // Enables or disables time skipping for this workflow execution.
     bool enabled = 1;
 
@@ -618,12 +615,12 @@ message TimeSkippingConfig {
     // signals, updates, or other external events while timers are in progress.
     oneof bound {
         // Maximum total virtual time that can be skipped.
-        google.protobuf.Duration max_skipped_duration = 4;
+        google.protobuf.Duration max_skipped_duration = 2;
 
         // Maximum elapsed time since time skipping was enabled.
         // This includes both skipped time and real time elapsing.
         // (-- api-linter: core::0142::time-field-names=disabled --)
-        google.protobuf.Duration max_elapsed_duration = 5;
+        google.protobuf.Duration max_elapsed_duration = 3;
     }
 }
 

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -592,28 +592,28 @@ message WorkflowExecutionOptions {
 // User timers are not classified as in-flight work and will be skipped over.
 // When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.
 message TimeSkippingConfig {
+    reserved 2;
+    reserved "disable_propagation";
 
     // Enables or disables time skipping for this workflow execution.
-    // By default, this field is propagated to transitively related workflows (child workflows/start-as-new/reset) 
-    // at the time they are started.
-    // Changes made after a transitively related workflow has started are not propagated.
     bool enabled = 1;
 
-    // If set, the enabled field is not propagated to transitively related workflows.
-    bool disable_propagation = 2;
+    // If this execution was started by a previous execution that already skipped some time,
+    // it inherits the virtual time through the propagated skipped duration.
+    google.protobuf.Duration propagated_skipped_duration = 3;
 
-    // Optional bound that limits how long time skipping remains active.
-    // Once the bound is reached, time skipping is automatically disabled.
-    // It can later be re-enabled via UpdateWorkflowExecutionOptions.
+    // Optional bound that limits how far virtual time can advance while time skipping is active.
+    // Once the bound is reached, time skipping is automatically disabled,
+    // but can be re-enabled via UpdateWorkflowExecutionOptions.
     //
-    // This is particularly useful in testing scenarios where workflows
-    // are expected to receive signals, updates, or other events while
-    // timers are in progress.
+    // This is useful in testing scenarios where a workflow is expected to receive
+    // signals, updates, or other external events while timers are in progress.
     //
-    // This bound is not propagated to transitively related workflows. 
-    // When bound is also needed for transitively related workflows,
-    // it is recommended to set disable_propagation to true 
-    // and configure TimeSkippingConfig explicitly for transitively related workflows.
+    // Bound scope:
+    // - Each bound is independent for each workflow execution.
+    //   When a bound is propagated to a child workflow, the child's bound is only applied to that child execution.
+    // - Continue-as-new is an exception: continued workflow executions are treated as extensions of the
+    //   original execution, so the bound is shared across all executions in the chain.
     oneof bound {
 
         // Maximum total virtual time that can be skipped.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -199,8 +199,15 @@ message StartWorkflowExecutionRequest {
     temporal.api.common.v1.Priority priority = 27;
     // Deployment Options of the worker who will process the eager task. Passed when `request_eager_execution=true`.
     temporal.api.deployment.v1.WorkerDeploymentOptions eager_worker_deployment_options = 28;
+
     // Time-skipping configuration. If not set, time skipping is disabled.
     temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 29;
+
+    // If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new) 
+    // that has already skipped some time, the accumulated skipped duration from that execution 
+    // can be passed to the new workflow execution through this field.
+    google.protobuf.Duration initial_skipped_duration = 30;
+
 }
 
 message StartWorkflowExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -202,7 +202,6 @@ message StartWorkflowExecutionRequest {
 
     // Time-skipping configuration. If not set, time skipping is disabled.
     temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 29;
-
 }
 
 message StartWorkflowExecutionResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -203,11 +203,6 @@ message StartWorkflowExecutionRequest {
     // Time-skipping configuration. If not set, time skipping is disabled.
     temporal.api.workflow.v1.TimeSkippingConfig time_skipping_config = 29;
 
-    // If a workflow execution is started by a previous execution (parent-child workflow or continue-as-new) 
-    // that has already skipped some time, the accumulated skipped duration from that execution 
-    // can be passed to the new workflow execution through this field.
-    google.protobuf.Duration initial_skipped_duration = 30;
-
 }
 
 message StartWorkflowExecutionResponse {


### PR DESCRIPTION
**What changed and why?**

Propagation refers to how time-skipping config is carried over to all workflows started by the current workflow: retry, continue-as-new, child workflows, reset, etc.

1. Remove **disable_propagation** and **max_target_time**, because neither of them can be soundly defined when time-skipping propagates transitively across related workflows. One of the many examples:

- max_target_time: as an absolute time point, it may already have passed by the time a retry or downstream workflow starts, making it ambiguous whether to disable or preserve time-skipping — neither is a clearly correct default
- disable_propagation: it is unclear which type of transitively triggered workflow this should apply to, and treating all cases uniformly is unreasonable; we defer exposing this flexibility until user demand and use cases are better understood

2. Add **comments of the propagation behavior** for each feature (retry, continue-as-new, child workflow, reset, cron)
3. Add **comments to the bound field**
4. Add **propagatedSkippedDuration** to time skipping config so that new workflows can inherit the virtual time
