### PR TITLE
Add worker_commands namespace capability

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15472,6 +15472,10 @@
         "pollerAutoscaling": {
           "type": "boolean",
           "title": "True if the namespace supports poller autoscaling"
+        },
+        "workerCommands": {
+          "type": "boolean",
+          "description": "True if the namespace supports worker commands (server-to-worker communication via control queues)."
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12077,6 +12077,9 @@ components:
         pollerAutoscaling:
           type: boolean
           description: True if the namespace supports poller autoscaling
+        workerCommands:
+          type: boolean
+          description: True if the namespace supports worker commands (server-to-worker communication via control queues).
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -50,6 +50,8 @@ message NamespaceInfo {
         bool worker_poll_complete_on_shutdown = 8;
         // True if the namespace supports poller autoscaling
         bool poller_autoscaling = 9;
+        // True if the namespace supports worker commands (server-to-worker communication via control queues).
+        bool worker_commands = 10;
     }
 
     // Namespace configured limits


### PR DESCRIPTION
## What
Add `worker_commands` bool field to capabilities.

## Why
This feature requires SDK to implicitly create a new task queue and poller per process. Preferable to do this in a controlled manner.

## How did you test it?
Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)