### PR TITLE
Add weak consistency option to DescribeNamespaceRequest

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -150,6 +150,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "weakConsistency",
+            "description": "If true, the server may serve the response from an eventually-consistent\nsource instead of reading through to persistence. Defaults to false,\nwhich preserves read-after-write consistency. SDKs should set this when\nfetching namespace capabilities on worker/client startup.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -5013,6 +5020,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "weakConsistency",
+            "description": "If true, the server may serve the response from an eventually-consistent\nsource instead of reading through to persistence. Defaults to false,\nwhich preserves read-after-write consistency. SDKs should set this when\nfetching namespace capabilities on worker/client startup.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -109,6 +109,15 @@ paths:
           in: query
           schema:
             type: string
+        - name: weakConsistency
+          in: query
+          description: |-
+            If true, the server may serve the response from an eventually-consistent
+             source instead of reading through to persistence. Defaults to false,
+             which preserves read-after-write consistency. SDKs should set this when
+             fetching namespace capabilities on worker/client startup.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -4466,6 +4475,15 @@ paths:
           in: query
           schema:
             type: string
+        - name: weakConsistency
+          in: query
+          description: |-
+            If true, the server may serve the response from an eventually-consistent
+             source instead of reading through to persistence. Defaults to false,
+             which preserves read-after-write consistency. SDKs should set this when
+             fetching namespace capabilities on worker/client startup.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -86,6 +86,11 @@ message ListNamespacesResponse {
 message DescribeNamespaceRequest {
     string namespace = 1;
     string id = 2;
+    // If true, the server may serve the response from an eventually-consistent
+    // source instead of reading through to persistence. Defaults to false,
+    // which preserves read-after-write consistency. SDKs should set this when
+    // fetching namespace capabilities on worker/client startup.
+    bool weak_consistency = 3;
 }
 
 message DescribeNamespaceResponse {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added weak_consistency boolean field to `DescribeNamespaceRequest`. When set to `true`, the server may serve the response from an eventually-consistent source (e.g. the in-memory namespace registry) instead of reading through to persistence.

<!-- Tell your future self why have you made these changes -->
**Why?**
`DescribeNamespace` currently always reads through to the persistence store. The new field lets clients opt into eventually-consistent reads where read-after-write semantics aren't required, while preserving the existing strong-consistency contract for operator/admin callers (default behavior unchanged).

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
None. Additive field with default `false`, preserving current behavior for clients that don't set it.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/10103