### PR TITLE
Add option to exclude system workers in ListWorkers API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -3488,6 +3488,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "includeSystemWorkers",
+            "description": "When true, the response will include system workers that are created implicitly\nby the server and not by the user. By default, system workers are excluded.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -8956,6 +8963,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "includeSystemWorkers",
+            "description": "When true, the response will include system workers that are created implicitly\nby the server and not by the user. By default, system workers are excluded.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -3161,6 +3161,13 @@ paths:
             * Status
           schema:
             type: string
+        - name: includeSystemWorkers
+          in: query
+          description: |-
+            When true, the response will include system workers that are created implicitly
+             by the server and not by the user. By default, system workers are excluded.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -8099,6 +8106,13 @@ paths:
             * Status
           schema:
             type: string
+        - name: includeSystemWorkers
+          in: query
+          description: |-
+            When true, the response will include system workers that are created implicitly
+             by the server and not by the user. By default, system workers are excluded.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2783,8 +2783,8 @@ message ListWorkersRequest {
     //* Status
     string query = 4;
 
-    // When true, the response will include system workers (those on internal task queues
-    // like temporal-sys-*). By default, system workers are excluded.
+    // When true, the response will include system workers that are created implicitly
+    // by the server and not by the user. By default, system workers are excluded.
     bool include_system_workers = 5;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2782,6 +2782,10 @@ message ListWorkersRequest {
     //* StartTime
     //* Status
     string query = 4;
+
+    // When true, the response will include system workers (those on internal task queues
+    // like temporal-sys-*). By default, system workers are excluded.
+    bool include_system_workers = 5;
 }
 
 message ListWorkersResponse {


### PR DESCRIPTION
## What
Add `bool include_system_workers` field to `ListWorkersRequest` proto. When true, the response includes system workers that are not created by the user. By default, system workers are excluded.

## Why
System workers (per-namespace workers for scheduler, batcher, etc.) show up in ListWorkers results, which is confusing for users who only care about their own workers.

## How did you test it?
Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)