### PR TITLE
Add API for GetWorkflowExecutionResult

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10796,10 +10796,18 @@
       },
       "description": "Target a worker polling on a Nexus task queue in a specific namespace."
     },
-    "GetWorkflowExecutionResultResponseNotCompleted": {
+    "GetWorkflowExecutionResultResponseFailed": {
+      "type": "object",
+      "properties": {
+        "failure": {
+          "$ref": "#/definitions/v1Failure"
+        }
+      }
+    },
+    "GetWorkflowExecutionResultResponseRunning": {
       "type": "object"
     },
-    "GetWorkflowExecutionResultResponseSuccess": {
+    "GetWorkflowExecutionResultResponseSucceed": {
       "type": "object",
       "properties": {
         "result": {
@@ -13108,7 +13116,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -13171,7 +13179,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -13211,58 +13219,6 @@
         }
       },
       "description": "When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and\nthere is already an existing running workflow, OnConflictOptions defines actions to be taken on\nthe existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent\nhistory event in the running workflow with the changes requested in this object."
-    },
-    "failureV1Failure": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string",
-          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
-        },
-        "stackTrace": {
-          "type": "string"
-        },
-        "encodedAttributes": {
-          "$ref": "#/definitions/v1Payload",
-          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
-        },
-        "cause": {
-          "$ref": "#/definitions/failureV1Failure"
-        },
-        "applicationFailureInfo": {
-          "$ref": "#/definitions/v1ApplicationFailureInfo"
-        },
-        "timeoutFailureInfo": {
-          "$ref": "#/definitions/v1TimeoutFailureInfo"
-        },
-        "canceledFailureInfo": {
-          "$ref": "#/definitions/v1CanceledFailureInfo"
-        },
-        "terminatedFailureInfo": {
-          "$ref": "#/definitions/v1TerminatedFailureInfo"
-        },
-        "serverFailureInfo": {
-          "$ref": "#/definitions/v1ServerFailureInfo"
-        },
-        "resetWorkflowFailureInfo": {
-          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
-        },
-        "activityFailureInfo": {
-          "$ref": "#/definitions/v1ActivityFailureInfo"
-        },
-        "childWorkflowExecutionFailureInfo": {
-          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
-        },
-        "nexusOperationExecutionFailureInfo": {
-          "$ref": "#/definitions/v1NexusOperationFailureInfo"
-        },
-        "nexusHandlerFailureInfo": {
-          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
-        }
-      }
     },
     "protobufAny": {
       "type": "object",
@@ -13378,7 +13334,7 @@
           "description": "Time when the activity transitioned to a closed state."
         },
         "lastFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details from the last failed attempt."
         },
         "lastWorkerIdentity": {
@@ -13508,7 +13464,7 @@
           "description": "The result if the activity completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The failure if the activity completed unsuccessfully."
         }
       },
@@ -13698,7 +13654,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "title": "Failure details"
         },
         "scheduledEventId": {
@@ -13800,7 +13756,7 @@
           "title": "Starting at 1, the number of times this task has been attempted"
         },
         "lastFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Will be set to the most recent failure details, if this task has previously failed and then\nbeen retried."
         },
         "workerVersion": {
@@ -13818,7 +13774,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "If this activity had failed, was retried, and then timed out, that failure is stored as the\n`cause` in here."
         },
         "scheduledEventId": {
@@ -14386,7 +14342,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/failureV1Failure"
+          "$ref": "#/definitions/v1Failure"
         },
         "namespace": {
           "type": "string",
@@ -15171,7 +15127,7 @@
           "description": "The result if the operation completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The failure if the operation completed unsuccessfully."
         },
         "longPollToken": {
@@ -15551,6 +15507,58 @@
       },
       "title": "Represents a historical replication status of a Namespace"
     },
+    "v1Failure": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "encodedAttributes": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
+        },
+        "cause": {
+          "$ref": "#/definitions/v1Failure"
+        },
+        "applicationFailureInfo": {
+          "$ref": "#/definitions/v1ApplicationFailureInfo"
+        },
+        "timeoutFailureInfo": {
+          "$ref": "#/definitions/v1TimeoutFailureInfo"
+        },
+        "canceledFailureInfo": {
+          "$ref": "#/definitions/v1CanceledFailureInfo"
+        },
+        "terminatedFailureInfo": {
+          "$ref": "#/definitions/v1TerminatedFailureInfo"
+        },
+        "serverFailureInfo": {
+          "$ref": "#/definitions/v1ServerFailureInfo"
+        },
+        "resetWorkflowFailureInfo": {
+          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
+        },
+        "activityFailureInfo": {
+          "$ref": "#/definitions/v1ActivityFailureInfo"
+        },
+        "childWorkflowExecutionFailureInfo": {
+          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
+        },
+        "nexusOperationExecutionFailureInfo": {
+          "$ref": "#/definitions/v1NexusOperationFailureInfo"
+        },
+        "nexusHandlerFailureInfo": {
+          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
+        }
+      }
+    },
     "v1FetchWorkerConfigResponse": {
       "type": "object",
       "properties": {
@@ -15809,22 +15817,14 @@
           },
           "title": "Link to the relevant history event:\n- completion event, if the workflow has finished\n- options-updated event, if callbacks were registered on a running workflow"
         },
-        "notCompleted": {
-          "$ref": "#/definitions/GetWorkflowExecutionResultResponseNotCompleted"
+        "running": {
+          "$ref": "#/definitions/GetWorkflowExecutionResultResponseRunning"
         },
-        "success": {
-          "$ref": "#/definitions/GetWorkflowExecutionResultResponseSuccess"
+        "succeed": {
+          "$ref": "#/definitions/GetWorkflowExecutionResultResponseSucceed"
         },
-        "failure": {
-          "$ref": "#/definitions/v1GetWorkflowExecutionResultResponseFailure"
-        }
-      }
-    },
-    "v1GetWorkflowExecutionResultResponseFailure": {
-      "type": "object",
-      "properties": {
-        "failure": {
-          "$ref": "#/definitions/failureV1Failure"
+        "failed": {
+          "$ref": "#/definitions/GetWorkflowExecutionResultResponseFailed"
         }
       }
     },
@@ -16438,7 +16438,7 @@
           "$ref": "#/definitions/v1Header"
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Some uses of markers, like a local activity, could \"fail\". If they did that is recorded here."
         }
       }
@@ -16784,7 +16784,7 @@
           "description": "The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported\nwith."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "scheduledEventId": {
@@ -16818,7 +16818,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Cancellation details."
         },
         "requestId": {
@@ -16850,7 +16850,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -16920,7 +16920,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -17007,7 +17007,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -17144,7 +17144,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo."
         },
         "requestId": {
@@ -17292,7 +17292,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "requestId": {
@@ -17319,7 +17319,7 @@
           "$ref": "#/definitions/v1Payloads"
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure"
+          "$ref": "#/definitions/v1Failure"
         }
       },
       "description": "The outcome of a Workflow Update: success or failure."
@@ -17406,7 +17406,7 @@
           "format": "date-time"
         },
         "lastFailure": {
-          "$ref": "#/definitions/failureV1Failure"
+          "$ref": "#/definitions/v1Failure"
         },
         "lastWorkerIdentity": {
           "type": "string"
@@ -17544,7 +17544,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -17670,7 +17670,7 @@
           "description": "The result if the operation completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The failure if the operation completed unsuccessfully."
         }
       }
@@ -18341,7 +18341,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/failureV1Failure"
+            "$ref": "#/definitions/v1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -18354,7 +18354,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/failureV1Failure"
+            "$ref": "#/definitions/v1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -20625,7 +20625,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "Deprecated. If a workflow's retry policy would cause a new run to start when the current one\nhas failed, this field would be populated with that failure. Now (when supported by server\nand sdk) the final event will be `WORKFLOW_EXECUTION_FAILED` with `new_execution_run_id` set."
         },
         "lastCompletionResult": {
@@ -20700,7 +20700,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "title": "Serialized result of workflow failure (ex: An exception thrown, or error returned)"
         },
         "retryState": {
@@ -20993,7 +20993,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "continuedFailure": {
-          "$ref": "#/definitions/failureV1Failure"
+          "$ref": "#/definitions/v1Failure"
         },
         "lastCompletionResult": {
           "$ref": "#/definitions/v1Payloads"
@@ -21267,7 +21267,7 @@
           "description": "The message payload of the original request message that initiated this\nupdate."
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "description": "The cause of rejection."
         }
       }
@@ -21603,7 +21603,7 @@
           "$ref": "#/definitions/v1WorkflowTaskFailedCause"
         },
         "failure": {
-          "$ref": "#/definitions/failureV1Failure",
+          "$ref": "#/definitions/v1Failure",
           "title": "The failure details"
         },
         "identity": {

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10818,33 +10818,14 @@
       },
       "description": "Target a worker polling on a Nexus task queue in a specific namespace."
     },
-    "GetWorkflowExecutionResultResponseCompleted": {
-      "type": "object",
-      "properties": {
-        "execution": {
-          "$ref": "#/definitions/v1WorkflowExecution"
-        },
-        "status": {
-          "$ref": "#/definitions/v1WorkflowExecutionStatus"
-        },
-        "result": {
-          "$ref": "#/definitions/v1Payloads",
-          "description": "Set only when status = COMPLETED."
-        },
-        "failure": {
-          "$ref": "#/definitions/v1Failure",
-          "description": "Set for FAILED / CANCELED / TERMINATED / TIMED_OUT."
-        }
-      }
-    },
     "GetWorkflowExecutionResultResponseNotCompleted": {
+      "type": "object"
+    },
+    "GetWorkflowExecutionResultResponseSuccess": {
       "type": "object",
       "properties": {
-        "execution": {
-          "$ref": "#/definitions/v1WorkflowExecution"
-        },
-        "status": {
-          "$ref": "#/definitions/v1WorkflowExecutionStatus"
+        "result": {
+          "$ref": "#/definitions/v1Payloads"
         }
       }
     },
@@ -13111,7 +13092,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -13174,7 +13155,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -13214,6 +13195,58 @@
         }
       },
       "description": "When StartWorkflowExecution uses the conflict policy WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING and\nthere is already an existing running workflow, OnConflictOptions defines actions to be taken on\nthe existing running workflow. In this case, it will create a WorkflowExecutionOptionsUpdatedEvent\nhistory event in the running workflow with the changes requested in this object."
+    },
+    "failureV1Failure": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "encodedAttributes": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
+        },
+        "cause": {
+          "$ref": "#/definitions/failureV1Failure"
+        },
+        "applicationFailureInfo": {
+          "$ref": "#/definitions/v1ApplicationFailureInfo"
+        },
+        "timeoutFailureInfo": {
+          "$ref": "#/definitions/v1TimeoutFailureInfo"
+        },
+        "canceledFailureInfo": {
+          "$ref": "#/definitions/v1CanceledFailureInfo"
+        },
+        "terminatedFailureInfo": {
+          "$ref": "#/definitions/v1TerminatedFailureInfo"
+        },
+        "serverFailureInfo": {
+          "$ref": "#/definitions/v1ServerFailureInfo"
+        },
+        "resetWorkflowFailureInfo": {
+          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
+        },
+        "activityFailureInfo": {
+          "$ref": "#/definitions/v1ActivityFailureInfo"
+        },
+        "childWorkflowExecutionFailureInfo": {
+          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
+        },
+        "nexusOperationExecutionFailureInfo": {
+          "$ref": "#/definitions/v1NexusOperationFailureInfo"
+        },
+        "nexusHandlerFailureInfo": {
+          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
+        }
+      }
     },
     "protobufAny": {
       "type": "object",
@@ -13329,7 +13362,7 @@
           "description": "Time when the activity transitioned to a closed state."
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Failure details from the last failed attempt."
         },
         "lastWorkerIdentity": {
@@ -13459,7 +13492,7 @@
           "description": "The result if the activity completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The failure if the activity completed unsuccessfully."
         }
       },
@@ -13649,7 +13682,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "title": "Failure details"
         },
         "scheduledEventId": {
@@ -13751,7 +13784,7 @@
           "title": "Starting at 1, the number of times this task has been attempted"
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Will be set to the most recent failure details, if this task has previously failed and then\nbeen retried."
         },
         "workerVersion": {
@@ -13769,7 +13802,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "If this activity had failed, was retried, and then timed out, that failure is stored as the\n`cause` in here."
         },
         "scheduledEventId": {
@@ -14337,7 +14370,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/failureV1Failure"
         },
         "namespace": {
           "type": "string",
@@ -15122,7 +15155,7 @@
           "description": "The result if the operation completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The failure if the operation completed unsuccessfully."
         },
         "longPollToken": {
@@ -15502,58 +15535,6 @@
       },
       "title": "Represents a historical replication status of a Namespace"
     },
-    "v1Failure": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string",
-          "description": "The source this Failure originated in, e.g. TypeScriptSDK / JavaSDK\nIn some SDKs this is used to rehydrate the stack trace into an exception object."
-        },
-        "stackTrace": {
-          "type": "string"
-        },
-        "encodedAttributes": {
-          "$ref": "#/definitions/v1Payload",
-          "description": "Alternative way to supply `message` and `stack_trace` and possibly other attributes, used for encryption of\nerrors originating in user code which might contain sensitive information.\nThe `encoded_attributes` Payload could represent any serializable object, e.g. JSON object or a `Failure` proto\nmessage.\n\nSDK authors:\n- The SDK should provide a default `encodeFailureAttributes` and `decodeFailureAttributes` implementation that:\n  - Uses a JSON object to represent `{ message, stack_trace }`.\n  - Overwrites the original message with \"Encoded failure\" to indicate that more information could be extracted.\n  - Overwrites the original stack_trace with an empty string.\n  - The resulting JSON object is converted to Payload using the default PayloadConverter and should be processed\n    by the user-provided PayloadCodec\n\n- If there's demand, we could allow overriding the default SDK implementation to encode other opaque Failure attributes."
-        },
-        "cause": {
-          "$ref": "#/definitions/v1Failure"
-        },
-        "applicationFailureInfo": {
-          "$ref": "#/definitions/v1ApplicationFailureInfo"
-        },
-        "timeoutFailureInfo": {
-          "$ref": "#/definitions/v1TimeoutFailureInfo"
-        },
-        "canceledFailureInfo": {
-          "$ref": "#/definitions/v1CanceledFailureInfo"
-        },
-        "terminatedFailureInfo": {
-          "$ref": "#/definitions/v1TerminatedFailureInfo"
-        },
-        "serverFailureInfo": {
-          "$ref": "#/definitions/v1ServerFailureInfo"
-        },
-        "resetWorkflowFailureInfo": {
-          "$ref": "#/definitions/v1ResetWorkflowFailureInfo"
-        },
-        "activityFailureInfo": {
-          "$ref": "#/definitions/v1ActivityFailureInfo"
-        },
-        "childWorkflowExecutionFailureInfo": {
-          "$ref": "#/definitions/v1ChildWorkflowExecutionFailureInfo"
-        },
-        "nexusOperationExecutionFailureInfo": {
-          "$ref": "#/definitions/v1NexusOperationFailureInfo"
-        },
-        "nexusHandlerFailureInfo": {
-          "$ref": "#/definitions/v1NexusHandlerFailureInfo"
-        }
-      }
-    },
     "v1FetchWorkerConfigResponse": {
       "type": "object",
       "properties": {
@@ -15800,6 +15781,12 @@
     "v1GetWorkflowExecutionResultResponse": {
       "type": "object",
       "properties": {
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution"
+        },
+        "status": {
+          "$ref": "#/definitions/v1WorkflowExecutionStatus"
+        },
         "links": {
           "type": "array",
           "items": {
@@ -15811,8 +15798,19 @@
         "notCompleted": {
           "$ref": "#/definitions/GetWorkflowExecutionResultResponseNotCompleted"
         },
-        "completed": {
-          "$ref": "#/definitions/GetWorkflowExecutionResultResponseCompleted"
+        "success": {
+          "$ref": "#/definitions/GetWorkflowExecutionResultResponseSuccess"
+        },
+        "failure": {
+          "$ref": "#/definitions/v1GetWorkflowExecutionResultResponseFailure"
+        }
+      }
+    },
+    "v1GetWorkflowExecutionResultResponseFailure": {
+      "type": "object",
+      "properties": {
+        "failure": {
+          "$ref": "#/definitions/failureV1Failure"
         }
       }
     },
@@ -16426,7 +16424,7 @@
           "$ref": "#/definitions/v1Header"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Some uses of markers, like a local activity, could \"fail\". If they did that is recorded here."
         }
       }
@@ -16768,7 +16766,7 @@
           "description": "The `WORKFLOW_TASK_COMPLETED` event that the corresponding RequestCancelNexusOperation command was reported\nwith."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "scheduledEventId": {
@@ -16802,7 +16800,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Cancellation details."
         },
         "requestId": {
@@ -16834,7 +16832,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -16904,7 +16902,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -16991,7 +16989,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -17128,7 +17126,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo."
         },
         "requestId": {
@@ -17276,7 +17274,7 @@
           "description": "The ID of the `NEXUS_OPERATION_SCHEDULED` event. Uniquely identifies this operation."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo."
         },
         "requestId": {
@@ -17303,7 +17301,7 @@
           "$ref": "#/definitions/v1Payloads"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/failureV1Failure"
         }
       },
       "description": "The outcome of a Workflow Update: success or failure."
@@ -17390,7 +17388,7 @@
           "format": "date-time"
         },
         "lastFailure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/failureV1Failure"
         },
         "lastWorkerIdentity": {
           "type": "string"
@@ -17528,7 +17526,7 @@
           "description": "The time when the last attempt completed."
         },
         "lastAttemptFailure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The last attempt's failure, if any."
         },
         "nextAttemptScheduleTime": {
@@ -17654,7 +17652,7 @@
           "description": "The result if the operation completed successfully."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The failure if the operation completed unsuccessfully."
         }
       }
@@ -18325,7 +18323,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Failure"
+            "$ref": "#/definitions/failureV1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -18338,7 +18336,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1Failure"
+            "$ref": "#/definitions/failureV1Failure"
           },
           "title": "Server validation failures could include\nlast_heartbeat_details payload is too large, request failure is too large"
         }
@@ -20609,7 +20607,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "Deprecated. If a workflow's retry policy would cause a new run to start when the current one\nhas failed, this field would be populated with that failure. Now (when supported by server\nand sdk) the final event will be `WORKFLOW_EXECUTION_FAILED` with `new_execution_run_id` set."
         },
         "lastCompletionResult": {
@@ -20684,7 +20682,7 @@
       "type": "object",
       "properties": {
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "title": "Serialized result of workflow failure (ex: An exception thrown, or error returned)"
         },
         "retryState": {
@@ -20977,7 +20975,7 @@
           "$ref": "#/definitions/v1ContinueAsNewInitiator"
         },
         "continuedFailure": {
-          "$ref": "#/definitions/v1Failure"
+          "$ref": "#/definitions/failureV1Failure"
         },
         "lastCompletionResult": {
           "$ref": "#/definitions/v1Payloads"
@@ -21251,7 +21249,7 @@
           "description": "The message payload of the original request message that initiated this\nupdate."
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "description": "The cause of rejection."
         }
       }
@@ -21587,7 +21585,7 @@
           "$ref": "#/definitions/v1WorkflowTaskFailedCause"
         },
         "failure": {
-          "$ref": "#/definitions/v1Failure",
+          "$ref": "#/definitions/failureV1Failure",
           "title": "The failure details"
         },
         "identity": {

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -4173,13 +4173,14 @@
           },
           {
             "name": "requestId",
-            "description": "Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).",
+            "description": "A unique identifier for this create request for idempotence. Typically UUIDv4.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "identity",
+            "description": "The identity of the client who initiated this request.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -9704,13 +9705,14 @@
           },
           {
             "name": "requestId",
-            "description": "Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).",
+            "description": "A unique identifier for this create request for idempotence. Typically UUIDv4.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "identity",
+            "description": "The identity of the client who initiated this request.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -15782,10 +15784,8 @@
       "type": "object",
       "properties": {
         "execution": {
-          "$ref": "#/definitions/v1WorkflowExecution"
-        },
-        "status": {
-          "$ref": "#/definitions/v1WorkflowExecutionStatus"
+          "$ref": "#/definitions/v1WorkflowExecution",
+          "description": "Information about the workflow execution, including the runID that this result is associated to."
         },
         "links": {
           "type": "array",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -4134,6 +4134,62 @@
         ]
       }
     },
+    "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/result": {
+      "get": {
+        "summary": "GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow\nis still running, returns a NotCompleted response and optionally registers callbacks\nto be invoked when the workflow completes.",
+        "operationId": "GetWorkflowExecutionResult2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWorkflowExecutionResultResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "execution.workflowId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "execution.runId",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "requestId",
+            "description": "Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "identity",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/trigger-rule": {
       "post": {
         "summary": "TriggerWorkflowRule allows to:\n * trigger existing rule for a specific workflow execution;\n * trigger rule for a specific workflow execution without creating a rule;\nThis is useful for one-off operations.",
@@ -9609,6 +9665,62 @@
         ]
       }
     },
+    "/namespaces/{namespace}/workflows/{execution.workflowId}/result": {
+      "get": {
+        "summary": "GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow\nis still running, returns a NotCompleted response and optionally registers callbacks\nto be invoked when the workflow completes.",
+        "operationId": "GetWorkflowExecutionResult",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetWorkflowExecutionResultResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "execution.workflowId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "execution.runId",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "requestId",
+            "description": "Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "identity",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
     "/namespaces/{namespace}/workflows/{execution.workflowId}/trigger-rule": {
       "post": {
         "summary": "TriggerWorkflowRule allows to:\n * trigger existing rule for a specific workflow execution;\n * trigger rule for a specific workflow execution without creating a rule;\nThis is useful for one-off operations.",
@@ -10705,6 +10817,36 @@
         }
       },
       "description": "Target a worker polling on a Nexus task queue in a specific namespace."
+    },
+    "GetWorkflowExecutionResultResponseCompleted": {
+      "type": "object",
+      "properties": {
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution"
+        },
+        "status": {
+          "$ref": "#/definitions/v1WorkflowExecutionStatus"
+        },
+        "result": {
+          "$ref": "#/definitions/v1Payloads",
+          "description": "Set only when status = COMPLETED."
+        },
+        "failure": {
+          "$ref": "#/definitions/v1Failure",
+          "description": "Set for FAILED / CANCELED / TERMINATED / TIMED_OUT."
+        }
+      }
+    },
+    "GetWorkflowExecutionResultResponseNotCompleted": {
+      "type": "object",
+      "properties": {
+        "execution": {
+          "$ref": "#/definitions/v1WorkflowExecution"
+        },
+        "status": {
+          "$ref": "#/definitions/v1WorkflowExecutionStatus"
+        }
+      }
     },
     "LinkActivity": {
       "type": "object",
@@ -15652,6 +15794,25 @@
           "type": "string",
           "format": "byte",
           "title": "Will be set if there are more history events than were included in this response"
+        }
+      }
+    },
+    "v1GetWorkflowExecutionResultResponse": {
+      "type": "object",
+      "properties": {
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Link"
+          },
+          "title": "Link to the relevant history event:\n- completion event, if the workflow has finished\n- options-updated event, if callbacks were registered on a running workflow"
+        },
+        "notCompleted": {
+          "$ref": "#/definitions/GetWorkflowExecutionResultResponseNotCompleted"
+        },
+        "completed": {
+          "$ref": "#/definitions/GetWorkflowExecutionResultResponseCompleted"
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -4135,8 +4135,8 @@
       }
     },
     "/api/v1/namespaces/{namespace}/workflows/{execution.workflowId}/result": {
-      "get": {
-        "summary": "GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow\nis still running, returns a NotCompleted response and optionally registers callbacks\nto be invoked when the workflow completes.",
+      "post": {
+        "summary": "GetWorkflowExecutionResult returns the state of a workflow execution, which may be still running,\ncompleted, or failed. It can optionally register new callbacks to be invoked when Workflow reaches\na terminal state.\nIf the workflow is completed, it returns the result of the completed workflow.\nNOTE: This has to be a POST since we're optionally attaching callbacks to the running workflow, which mutates it.",
         "operationId": "GetWorkflowExecutionResult2",
         "responses": {
           "200": {
@@ -4166,24 +4166,12 @@
             "type": "string"
           },
           {
-            "name": "execution.runId",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "requestId",
-            "description": "A unique identifier for this create request for idempotence. Typically UUIDv4.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "identity",
-            "description": "The identity of the client who initiated this request.",
-            "in": "query",
-            "required": false,
-            "type": "string"
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceGetWorkflowExecutionResultBody"
+            }
           }
         ],
         "tags": [
@@ -9667,8 +9655,8 @@
       }
     },
     "/namespaces/{namespace}/workflows/{execution.workflowId}/result": {
-      "get": {
-        "summary": "GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow\nis still running, returns a NotCompleted response and optionally registers callbacks\nto be invoked when the workflow completes.",
+      "post": {
+        "summary": "GetWorkflowExecutionResult returns the state of a workflow execution, which may be still running,\ncompleted, or failed. It can optionally register new callbacks to be invoked when Workflow reaches\na terminal state.\nIf the workflow is completed, it returns the result of the completed workflow.\nNOTE: This has to be a POST since we're optionally attaching callbacks to the running workflow, which mutates it.",
         "operationId": "GetWorkflowExecutionResult",
         "responses": {
           "200": {
@@ -9698,24 +9686,12 @@
             "type": "string"
           },
           {
-            "name": "execution.runId",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "requestId",
-            "description": "A unique identifier for this create request for idempotence. Typically UUIDv4.",
-            "in": "query",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "identity",
-            "description": "The identity of the client who initiated this request.",
-            "in": "query",
-            "required": false,
-            "type": "string"
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowServiceGetWorkflowExecutionResultBody"
+            }
           }
         ],
         "tags": [
@@ -11334,6 +11310,44 @@
         "resourceId": {
           "type": "string",
           "description": "Resource ID for routing. Contains the worker grouping key."
+        }
+      }
+    },
+    "WorkflowServiceGetWorkflowExecutionResultBody": {
+      "type": "object",
+      "properties": {
+        "execution": {
+          "type": "object",
+          "properties": {
+            "runId": {
+              "type": "string"
+            }
+          },
+          "description": "For now, server will always provide the result of the latest run of the workflow_id\nprovided even if the run_id is set here. We use WorkflowExecution message for forward\ncompatibility if we want to enable getting the result of a specific run_id in the future."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "A unique identifier for this request for idempotence. Typically UUIDv4."
+        },
+        "identity": {
+          "type": "string",
+          "description": "The identity of the client who initiated this request."
+        },
+        "completionCallbacks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Callback"
+          },
+          "description": "Callbacks to be called by the server when this worflow reaches a terminal state,\nin the case when we're getting the result of a running workflow.\nCallback addresses must be allowlisted in the server's dynamic configuration."
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiCommonV1Link"
+          },
+          "description": "Links to be associated with this request. Note that completion_callbacks may also have\nassociated links; links already included with a callback should not be duplicated here."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10807,7 +10807,7 @@
     "GetWorkflowExecutionResultResponseRunning": {
       "type": "object"
     },
-    "GetWorkflowExecutionResultResponseSucceed": {
+    "GetWorkflowExecutionResultResponseSuccess": {
       "type": "object",
       "properties": {
         "result": {
@@ -15820,8 +15820,8 @@
         "running": {
           "$ref": "#/definitions/GetWorkflowExecutionResultResponseRunning"
         },
-        "succeed": {
-          "$ref": "#/definitions/GetWorkflowExecutionResultResponseSucceed"
+        "success": {
+          "$ref": "#/definitions/GetWorkflowExecutionResultResponseSuccess"
         },
         "failed": {
           "$ref": "#/definitions/GetWorkflowExecutionResultResponseFailed"

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -3714,6 +3714,56 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/result:
+    get:
+      tags:
+        - WorkflowService
+      description: |-
+        GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow
+         is still running, returns a NotCompleted response and optionally registers callbacks
+         to be invoked when the workflow completes.
+      operationId: GetWorkflowExecutionResult
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: execution.workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: execution.workflowId
+          in: query
+          schema:
+            type: string
+        - name: execution.runId
+          in: query
+          schema:
+            type: string
+        - name: requestId
+          in: query
+          description: Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).
+          schema:
+            type: string
+        - name: identity
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetWorkflowExecutionResultResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/trigger-rule:
     post:
       tags:
@@ -8659,6 +8709,56 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
+  /namespaces/{namespace}/workflows/{execution.workflow_id}/result:
+    get:
+      tags:
+        - WorkflowService
+      description: |-
+        GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow
+         is still running, returns a NotCompleted response and optionally registers callbacks
+         to be invoked when the workflow completes.
+      operationId: GetWorkflowExecutionResult
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: execution.workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: execution.workflowId
+          in: query
+          schema:
+            type: string
+        - name: execution.runId
+          in: query
+          schema:
+            type: string
+        - name: requestId
+          in: query
+          description: Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).
+          schema:
+            type: string
+        - name: identity
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetWorkflowExecutionResultResponse'
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/workflows/{execution.workflow_id}/trigger-rule:
     post:
       tags:
@@ -12149,6 +12249,65 @@ components:
           type: string
           description: Will be set if there are more history events than were included in this response
           format: bytes
+    GetWorkflowExecutionResultResponse:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          description: |-
+            Link to the relevant history event:
+             - completion event, if the workflow has finished
+             - options-updated event, if callbacks were registered on a running workflow
+        notCompleted:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_NotCompleted'
+        completed:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Completed'
+    GetWorkflowExecutionResultResponse_Completed:
+      type: object
+      properties:
+        execution:
+          $ref: '#/components/schemas/WorkflowExecution'
+        status:
+          enum:
+            - WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
+            - WORKFLOW_EXECUTION_STATUS_RUNNING
+            - WORKFLOW_EXECUTION_STATUS_COMPLETED
+            - WORKFLOW_EXECUTION_STATUS_FAILED
+            - WORKFLOW_EXECUTION_STATUS_CANCELED
+            - WORKFLOW_EXECUTION_STATUS_TERMINATED
+            - WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
+            - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+            - WORKFLOW_EXECUTION_STATUS_PAUSED
+          type: string
+          format: enum
+        result:
+          allOf:
+            - $ref: '#/components/schemas/Payloads'
+          description: Set only when status = COMPLETED.
+        failure:
+          allOf:
+            - $ref: '#/components/schemas/Failure'
+          description: Set for FAILED / CANCELED / TERMINATED / TIMED_OUT.
+    GetWorkflowExecutionResultResponse_NotCompleted:
+      type: object
+      properties:
+        execution:
+          $ref: '#/components/schemas/WorkflowExecution'
+        status:
+          enum:
+            - WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
+            - WORKFLOW_EXECUTION_STATUS_RUNNING
+            - WORKFLOW_EXECUTION_STATUS_COMPLETED
+            - WORKFLOW_EXECUTION_STATUS_FAILED
+            - WORKFLOW_EXECUTION_STATUS_CANCELED
+            - WORKFLOW_EXECUTION_STATUS_TERMINATED
+            - WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
+            - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+            - WORKFLOW_EXECUTION_STATUS_PAUSED
+          type: string
+          format: enum
     GoogleProtobufAny:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -3744,11 +3744,12 @@ paths:
             type: string
         - name: requestId
           in: query
-          description: Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).
+          description: A unique identifier for this create request for idempotence. Typically UUIDv4.
           schema:
             type: string
         - name: identity
           in: query
+          description: The identity of the client who initiated this request.
           schema:
             type: string
       responses:
@@ -8739,11 +8740,12 @@ paths:
             type: string
         - name: requestId
           in: query
-          description: Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).
+          description: A unique identifier for this create request for idempotence. Typically UUIDv4.
           schema:
             type: string
         - name: identity
           in: query
+          description: The identity of the client who initiated this request.
           schema:
             type: string
       responses:
@@ -12253,20 +12255,9 @@ components:
       type: object
       properties:
         execution:
-          $ref: '#/components/schemas/WorkflowExecution'
-        status:
-          enum:
-            - WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
-            - WORKFLOW_EXECUTION_STATUS_RUNNING
-            - WORKFLOW_EXECUTION_STATUS_COMPLETED
-            - WORKFLOW_EXECUTION_STATUS_FAILED
-            - WORKFLOW_EXECUTION_STATUS_CANCELED
-            - WORKFLOW_EXECUTION_STATUS_TERMINATED
-            - WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
-            - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
-            - WORKFLOW_EXECUTION_STATUS_PAUSED
-          type: string
-          format: enum
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: Information about the workflow execution, including the runID that this result is associated to.
         links:
           type: array
           items:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12252,6 +12252,21 @@ components:
     GetWorkflowExecutionResultResponse:
       type: object
       properties:
+        execution:
+          $ref: '#/components/schemas/WorkflowExecution'
+        status:
+          enum:
+            - WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
+            - WORKFLOW_EXECUTION_STATUS_RUNNING
+            - WORKFLOW_EXECUTION_STATUS_COMPLETED
+            - WORKFLOW_EXECUTION_STATUS_FAILED
+            - WORKFLOW_EXECUTION_STATUS_CANCELED
+            - WORKFLOW_EXECUTION_STATUS_TERMINATED
+            - WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
+            - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
+            - WORKFLOW_EXECUTION_STATUS_PAUSED
+          type: string
+          format: enum
         links:
           type: array
           items:
@@ -12262,52 +12277,23 @@ components:
              - options-updated event, if callbacks were registered on a running workflow
         notCompleted:
           $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_NotCompleted'
-        completed:
-          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Completed'
-    GetWorkflowExecutionResultResponse_Completed:
+        success:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Success'
+        failure:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Failure'
+    GetWorkflowExecutionResultResponse_Failure:
       type: object
       properties:
-        execution:
-          $ref: '#/components/schemas/WorkflowExecution'
-        status:
-          enum:
-            - WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
-            - WORKFLOW_EXECUTION_STATUS_RUNNING
-            - WORKFLOW_EXECUTION_STATUS_COMPLETED
-            - WORKFLOW_EXECUTION_STATUS_FAILED
-            - WORKFLOW_EXECUTION_STATUS_CANCELED
-            - WORKFLOW_EXECUTION_STATUS_TERMINATED
-            - WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
-            - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
-            - WORKFLOW_EXECUTION_STATUS_PAUSED
-          type: string
-          format: enum
-        result:
-          allOf:
-            - $ref: '#/components/schemas/Payloads'
-          description: Set only when status = COMPLETED.
         failure:
-          allOf:
-            - $ref: '#/components/schemas/Failure'
-          description: Set for FAILED / CANCELED / TERMINATED / TIMED_OUT.
+          $ref: '#/components/schemas/Failure'
     GetWorkflowExecutionResultResponse_NotCompleted:
       type: object
+      properties: {}
+    GetWorkflowExecutionResultResponse_Success:
+      type: object
       properties:
-        execution:
-          $ref: '#/components/schemas/WorkflowExecution'
-        status:
-          enum:
-            - WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
-            - WORKFLOW_EXECUTION_STATUS_RUNNING
-            - WORKFLOW_EXECUTION_STATUS_COMPLETED
-            - WORKFLOW_EXECUTION_STATUS_FAILED
-            - WORKFLOW_EXECUTION_STATUS_CANCELED
-            - WORKFLOW_EXECUTION_STATUS_TERMINATED
-            - WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
-            - WORKFLOW_EXECUTION_STATUS_TIMED_OUT
-            - WORKFLOW_EXECUTION_STATUS_PAUSED
-          type: string
-          format: enum
+        result:
+          $ref: '#/components/schemas/Payloads'
     GoogleProtobufAny:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12279,21 +12279,21 @@ components:
             Link to the relevant history event:
              - completion event, if the workflow has finished
              - options-updated event, if callbacks were registered on a running workflow
-        notCompleted:
-          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_NotCompleted'
-        success:
-          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Success'
-        failure:
-          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Failure'
-    GetWorkflowExecutionResultResponse_Failure:
+        running:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Running'
+        succeed:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Succeed'
+        failed:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Failed'
+    GetWorkflowExecutionResultResponse_Failed:
       type: object
       properties:
         failure:
           $ref: '#/components/schemas/Failure'
-    GetWorkflowExecutionResultResponse_NotCompleted:
+    GetWorkflowExecutionResultResponse_Running:
       type: object
       properties: {}
-    GetWorkflowExecutionResultResponse_Success:
+    GetWorkflowExecutionResultResponse_Succeed:
       type: object
       properties:
         result:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -3715,13 +3715,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/Status'
   /api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/result:
-    get:
+    post:
       tags:
         - WorkflowService
       description: |-
-        GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow
-         is still running, returns a NotCompleted response and optionally registers callbacks
-         to be invoked when the workflow completes.
+        GetWorkflowExecutionResult returns the state of a workflow execution, which may be still running,
+         completed, or failed. It can optionally register new callbacks to be invoked when Workflow reaches
+         a terminal state.
+         If the workflow is completed, it returns the result of the completed workflow.
+         NOTE: This has to be a POST since we're optionally attaching callbacks to the running workflow, which mutates it.
       operationId: GetWorkflowExecutionResult
       parameters:
         - name: namespace
@@ -3734,24 +3736,12 @@ paths:
           required: true
           schema:
             type: string
-        - name: execution.workflowId
-          in: query
-          schema:
-            type: string
-        - name: execution.runId
-          in: query
-          schema:
-            type: string
-        - name: requestId
-          in: query
-          description: A unique identifier for this create request for idempotence. Typically UUIDv4.
-          schema:
-            type: string
-        - name: identity
-          in: query
-          description: The identity of the client who initiated this request.
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetWorkflowExecutionResultRequest'
+        required: true
       responses:
         "200":
           description: OK
@@ -8711,13 +8701,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/Status'
   /namespaces/{namespace}/workflows/{execution.workflow_id}/result:
-    get:
+    post:
       tags:
         - WorkflowService
       description: |-
-        GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow
-         is still running, returns a NotCompleted response and optionally registers callbacks
-         to be invoked when the workflow completes.
+        GetWorkflowExecutionResult returns the state of a workflow execution, which may be still running,
+         completed, or failed. It can optionally register new callbacks to be invoked when Workflow reaches
+         a terminal state.
+         If the workflow is completed, it returns the result of the completed workflow.
+         NOTE: This has to be a POST since we're optionally attaching callbacks to the running workflow, which mutates it.
       operationId: GetWorkflowExecutionResult
       parameters:
         - name: namespace
@@ -8730,24 +8722,12 @@ paths:
           required: true
           schema:
             type: string
-        - name: execution.workflowId
-          in: query
-          schema:
-            type: string
-        - name: execution.runId
-          in: query
-          schema:
-            type: string
-        - name: requestId
-          in: query
-          description: A unique identifier for this create request for idempotence. Typically UUIDv4.
-          schema:
-            type: string
-        - name: identity
-          in: query
-          description: The identity of the client who initiated this request.
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetWorkflowExecutionResultRequest'
+        required: true
       responses:
         "200":
           description: OK
@@ -12251,6 +12231,39 @@ components:
           type: string
           description: Will be set if there are more history events than were included in this response
           format: bytes
+    GetWorkflowExecutionResultRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+        execution:
+          allOf:
+            - $ref: '#/components/schemas/WorkflowExecution'
+          description: |-
+            For now, server will always provide the result of the latest run of the workflow_id
+             provided even if the run_id is set here. We use WorkflowExecution message for forward
+             compatibility if we want to enable getting the result of a specific run_id in the future.
+        requestId:
+          type: string
+          description: A unique identifier for this request for idempotence. Typically UUIDv4.
+        identity:
+          type: string
+          description: The identity of the client who initiated this request.
+        completionCallbacks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Callback'
+          description: |-
+            Callbacks to be called by the server when this worflow reaches a terminal state,
+             in the case when we're getting the result of a running workflow.
+             Callback addresses must be allowlisted in the server's dynamic configuration.
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          description: |-
+            Links to be associated with this request. Note that completion_callbacks may also have
+             associated links; links already included with a callback should not be duplicated here.
     GetWorkflowExecutionResultResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12281,8 +12281,8 @@ components:
              - options-updated event, if callbacks were registered on a running workflow
         running:
           $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Running'
-        succeed:
-          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Succeed'
+        success:
+          $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Success'
         failed:
           $ref: '#/components/schemas/GetWorkflowExecutionResultResponse_Failed'
     GetWorkflowExecutionResultResponse_Failed:
@@ -12293,7 +12293,7 @@ components:
     GetWorkflowExecutionResultResponse_Running:
       type: object
       properties: {}
-    GetWorkflowExecutionResultResponse_Succeed:
+    GetWorkflowExecutionResultResponse_Success:
       type: object
       properties:
         result:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1163,6 +1163,44 @@ message DescribeWorkflowExecutionResponse {
     temporal.api.workflow.v1.WorkflowExecutionExtendedInfo workflow_extended_info = 8;
 }
 
+message GetWorkflowExecutionResultRequest {
+    string namespace = 1;
+    temporal.api.common.v1.WorkflowExecution execution = 2;
+    // Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).
+    string request_id = 3;
+    string identity = 4;
+    // Callbacks and links to register if the workflow is not yet completed.
+    repeated temporal.api.common.v1.Callback callbacks = 5;
+    repeated temporal.api.common.v1.Link links = 6;
+}
+
+message GetWorkflowExecutionResultResponse {
+    // Link to the relevant history event:
+    // - completion event, if the workflow has finished
+    // - options-updated event, if callbacks were registered on a running workflow
+    repeated temporal.api.common.v1.Link links = 1;
+
+    // Completion status of the workflow, which carries relevant information for the caller.
+    oneof completion {
+        NotCompleted not_completed = 2;
+        Completed completed = 3;
+    }
+
+    message NotCompleted {
+        temporal.api.common.v1.WorkflowExecution execution = 1;
+        temporal.api.enums.v1.WorkflowExecutionStatus status = 2;
+    }
+
+    message Completed {
+        temporal.api.common.v1.WorkflowExecution execution = 1;
+        temporal.api.enums.v1.WorkflowExecutionStatus status    = 2;
+        // Set only when status = COMPLETED.
+        temporal.api.common.v1.Payloads result = 3;
+        // Set for FAILED / CANCELED / TERMINATED / TIMED_OUT.
+        temporal.api.failure.v1.Failure failure = 4;
+    }
+}
+
 // (-- api-linter: core::0203::optional=disabled
 //     aip.dev/not-precedent: field_behavior annotation not available in our gogo fork --)
 message DescribeTaskQueueRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1165,6 +1165,9 @@ message DescribeWorkflowExecutionResponse {
 
 message GetWorkflowExecutionResultRequest {
     string namespace = 1;
+    // For now, server will always provide the result of the latest run of the workflow_id
+    // provided even if the run_id is set here. We use WorkflowExecution message for forward
+    // compatibility if we want to enable getting the result of a specific run_id in the future.
     temporal.api.common.v1.WorkflowExecution execution = 2;
     // Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).
     string request_id = 3;
@@ -1175,29 +1178,29 @@ message GetWorkflowExecutionResultRequest {
 }
 
 message GetWorkflowExecutionResultResponse {
+    temporal.api.common.v1.WorkflowExecution execution = 1;
+    temporal.api.enums.v1.WorkflowExecutionStatus status = 2;
+
     // Link to the relevant history event:
     // - completion event, if the workflow has finished
     // - options-updated event, if callbacks were registered on a running workflow
-    repeated temporal.api.common.v1.Link links = 1;
+    repeated temporal.api.common.v1.Link links = 3;
 
     // Completion status of the workflow, which carries relevant information for the caller.
     oneof completion {
-        NotCompleted not_completed = 2;
-        Completed completed = 3;
+        NotCompleted not_completed = 4;
+        Success success = 5;
+        Failure failure = 6;
     }
 
-    message NotCompleted {
-        temporal.api.common.v1.WorkflowExecution execution = 1;
-        temporal.api.enums.v1.WorkflowExecutionStatus status = 2;
+    message NotCompleted {}
+
+    message Success {
+        temporal.api.common.v1.Payloads result = 1;
     }
 
-    message Completed {
-        temporal.api.common.v1.WorkflowExecution execution = 1;
-        temporal.api.enums.v1.WorkflowExecutionStatus status    = 2;
-        // Set only when status = COMPLETED.
-        temporal.api.common.v1.Payloads result = 3;
-        // Set for FAILED / CANCELED / TERMINATED / TIMED_OUT.
-        temporal.api.failure.v1.Failure failure = 4;
+    message Failure {
+        temporal.api.failure.v1.Failure failure = 2;
     }
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1169,11 +1169,12 @@ message GetWorkflowExecutionResultRequest {
     // provided even if the run_id is set here. We use WorkflowExecution message for forward
     // compatibility if we want to enable getting the result of a specific run_id in the future.
     temporal.api.common.v1.WorkflowExecution execution = 2;
-    // A unique identifier for this create request for idempotence. Typically UUIDv4.
+    // A unique identifier for this request for idempotence. Typically UUIDv4.
     string request_id = 3;
     // The identity of the client who initiated this request.
     string identity = 4;
-    // Callbacks to be called by the server when this activity reaches a terminal state.
+    // Callbacks to be called by the server when this worflow reaches a terminal state,
+    // in the case when we're getting the result of a running workflow.
     // Callback addresses must be allowlisted in the server's dynamic configuration.
     repeated temporal.api.common.v1.Callback completion_callbacks = 5;
     // Links to be associated with this request. Note that completion_callbacks may also have

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1193,18 +1193,18 @@ message GetWorkflowExecutionResultResponse {
 
     // Completion status of the workflow, which carries relevant information for the caller.
     oneof completion_status {
-        NotCompleted not_completed = 3;
-        Success success = 4;
-        Failure failure = 5;
+        Running running = 3;
+        Succeed succeed = 4;
+        Failed failed = 5;
     }
 
-    message NotCompleted {}
+    message Running {}
 
-    message Success {
+    message Succeed {
         temporal.api.common.v1.Payloads result = 1;
     }
 
-    message Failure {
+    message Failed {
         temporal.api.failure.v1.Failure failure = 1;
     }
 }

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1169,28 +1169,32 @@ message GetWorkflowExecutionResultRequest {
     // provided even if the run_id is set here. We use WorkflowExecution message for forward
     // compatibility if we want to enable getting the result of a specific run_id in the future.
     temporal.api.common.v1.WorkflowExecution execution = 2;
-    // Used to de-dup requests (i.e., so we don't register the same callbacks multiple times).
+    // A unique identifier for this create request for idempotence. Typically UUIDv4.
     string request_id = 3;
+    // The identity of the client who initiated this request.
     string identity = 4;
-    // Callbacks and links to register if the workflow is not yet completed.
-    repeated temporal.api.common.v1.Callback callbacks = 5;
+    // Callbacks to be called by the server when this activity reaches a terminal state.
+    // Callback addresses must be allowlisted in the server's dynamic configuration.
+    repeated temporal.api.common.v1.Callback completion_callbacks = 5;
+    // Links to be associated with this request. Note that completion_callbacks may also have
+    // associated links; links already included with a callback should not be duplicated here.
     repeated temporal.api.common.v1.Link links = 6;
 }
 
 message GetWorkflowExecutionResultResponse {
+    // Information about the workflow execution, including the runID that this result is associated to.
     temporal.api.common.v1.WorkflowExecution execution = 1;
-    temporal.api.enums.v1.WorkflowExecutionStatus status = 2;
 
     // Link to the relevant history event:
     // - completion event, if the workflow has finished
     // - options-updated event, if callbacks were registered on a running workflow
-    repeated temporal.api.common.v1.Link links = 3;
+    repeated temporal.api.common.v1.Link links = 2;
 
     // Completion status of the workflow, which carries relevant information for the caller.
-    oneof completion {
-        NotCompleted not_completed = 4;
-        Success success = 5;
-        Failure failure = 6;
+    oneof completion_status {
+        NotCompleted not_completed = 3;
+        Success success = 4;
+        Failure failure = 5;
     }
 
     message NotCompleted {}
@@ -1200,7 +1204,7 @@ message GetWorkflowExecutionResultResponse {
     }
 
     message Failure {
-        temporal.api.failure.v1.Failure failure = 2;
+        temporal.api.failure.v1.Failure failure = 1;
     }
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1194,13 +1194,13 @@ message GetWorkflowExecutionResultResponse {
     // Completion status of the workflow, which carries relevant information for the caller.
     oneof completion_status {
         Running running = 3;
-        Succeed succeed = 4;
+        Success success = 4;
         Failed failed = 5;
     }
 
     message Running {}
 
-    message Succeed {
+    message Success {
         temporal.api.common.v1.Payloads result = 1;
     }
 

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -2027,14 +2027,18 @@ service WorkflowService {
     //     aip.dev/not-precedent: Nexus operation deletion not exposed to HTTP, users should use cancel or terminate. --)
     rpc DeleteNexusOperationExecution (DeleteNexusOperationExecutionRequest) returns (DeleteNexusOperationExecutionResponse) {}
 
-    // GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow
-    // is still running, returns a NotCompleted response and optionally registers callbacks
-    // to be invoked when the workflow completes.
+    // GetWorkflowExecutionResult returns the state of a workflow execution, which may be still running,
+    // completed, or failed. It can optionally register new callbacks to be invoked when Workflow reaches
+    // a terminal state.
+    // If the workflow is completed, it returns the result of the completed workflow.
+    // NOTE: This has to be a POST since we're optionally attaching callbacks to the running workflow, which mutates it.
     rpc GetWorkflowExecutionResult (GetWorkflowExecutionResultRequest) returns (GetWorkflowExecutionResultResponse) {
         option (google.api.http) = {
-            get: "/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+            post: "/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+            body: "*"
             additional_bindings {
-                get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+                post: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+                body: "*"
             }
         };
         option (temporal.api.protometa.v1.request_header) = {

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -2023,4 +2023,20 @@ service WorkflowService {
     // (-- api-linter: core::0127::http-annotation=disabled
     //     aip.dev/not-precedent: Nexus operation deletion not exposed to HTTP, users should use cancel or terminate. --)
     rpc DeleteNexusOperationExecution (DeleteNexusOperationExecutionRequest) returns (DeleteNexusOperationExecutionResponse) {}
+
+    // GetWorkflowExecutionResult returns the result of a workflow execution. If the workflow
+    // is still running, returns a NotCompleted response and optionally registers callbacks
+    // to be invoked when the workflow completes.
+    rpc GetWorkflowExecutionResult (GetWorkflowExecutionResultRequest) returns (GetWorkflowExecutionResultResponse) {
+          option (google.api.http) = {
+                get: "/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+                additional_bindings {
+                    get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+                }
+          };
+          option (temporal.api.protometa.v1.request_header) = {
+                header: "temporal-resource-id"
+                value: "workflow:{execution.workflow_id}"
+          };
+    }
 }

--- a/temporal/api/workflowservice/v1/service.proto
+++ b/temporal/api/workflowservice/v1/service.proto
@@ -2028,15 +2028,15 @@ service WorkflowService {
     // is still running, returns a NotCompleted response and optionally registers callbacks
     // to be invoked when the workflow completes.
     rpc GetWorkflowExecutionResult (GetWorkflowExecutionResultRequest) returns (GetWorkflowExecutionResultResponse) {
-          option (google.api.http) = {
-                get: "/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
-                additional_bindings {
-                    get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
-                }
-          };
-          option (temporal.api.protometa.v1.request_header) = {
-                header: "temporal-resource-id"
-                value: "workflow:{execution.workflow_id}"
-          };
+        option (google.api.http) = {
+            get: "/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+            additional_bindings {
+                get: "/api/v1/namespaces/{namespace}/workflows/{execution.workflow_id}/result"
+            }
+        };
+        option (temporal.api.protometa.v1.request_header) = {
+            header: "temporal-resource-id"
+            value: "workflow:{execution.workflow_id}"
+        };
     }
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->

Add frontend API and request/response protos for getting workflow execution result.

Since this is intended to be used via Nexus, the API allows caller to attach callbacks for an ongoing workflow execution.


<!-- Tell your future self why have you made these changes -->
**Why?**
New API to enable Nexus ops to map more ergonomically in the handler.


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
Not breaking, new (unused) API

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/10173
