### PR TITLE
Add standalone Nexus operations namespace capability

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16454,6 +16454,10 @@
         "workerCommands": {
           "type": "boolean",
           "description": "True if the namespace supports worker commands (server-to-worker communication via control queues)."
+        },
+        "standaloneNexusOperation": {
+          "type": "boolean",
+          "description": "True if the namespace supports standalone Nexus operations."
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12924,6 +12924,9 @@ components:
         workerCommands:
           type: boolean
           description: True if the namespace supports worker commands (server-to-worker communication via control queues).
+        standaloneNexusOperation:
+          type: boolean
+          description: True if the namespace supports standalone Nexus operations.
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -52,6 +52,8 @@ message NamespaceInfo {
         bool poller_autoscaling = 9;
         // True if the namespace supports worker commands (server-to-worker communication via control queues).
         bool worker_commands = 10;
+        // True if the namespace supports standalone Nexus operations.
+        bool standalone_nexus_operation = 11;
     }
 
     // Namespace configured limits


### PR DESCRIPTION
## What changed?

Add `standalone_nexus_operations` to `NamespaceInfo.Capabilities`.

## Why?

Allows `DescribeNamespace` callers to determine whether standalone Nexus operations are available for a namespace.
