### PR TITLE
Add state_size_bytes to ScheduleInfo, ScheduleListInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -18397,6 +18397,11 @@
         "invalidScheduleError": {
           "type": "string",
           "description": "Deprecated."
+        },
+        "stateSizeBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Size of the schedule's internal state (including payloads) in bytes."
         }
       }
     },
@@ -18450,6 +18455,11 @@
             "type": "string",
             "format": "date-time"
           }
+        },
+        "stateSizeBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Size of the schedule's internal state (including payloads) in bytes."
         }
       },
       "description": "ScheduleListInfo is an abbreviated set of values from Schedule and ScheduleInfo\nthat's returned in ListSchedules."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15450,6 +15450,9 @@ components:
         invalidScheduleError:
           type: string
           description: Deprecated.
+        stateSizeBytes:
+          type: string
+          description: Size of the schedule's internal state (including payloads) in bytes.
     ScheduleListEntry:
       type: object
       properties:
@@ -15493,6 +15496,9 @@ components:
           items:
             type: string
             format: date-time
+        stateSizeBytes:
+          type: string
+          description: Size of the schedule's internal state (including payloads) in bytes.
       description: |-
         ScheduleListInfo is an abbreviated set of values from Schedule and ScheduleInfo
          that's returned in ListSchedules.

--- a/temporal/api/schedule/v1/message.proto
+++ b/temporal/api/schedule/v1/message.proto
@@ -349,6 +349,9 @@ message ScheduleInfo {
 
     // Deprecated.
     string invalid_schedule_error = 8 [deprecated = true];
+
+    // Size of the schedule's internal state (including payloads) in bytes.
+    int64 state_size_bytes = 12;
 }
 
 message Schedule {
@@ -377,6 +380,9 @@ message ScheduleListInfo {
     // From info (maybe fewer entries):
     repeated ScheduleActionResult recent_actions = 5;
     repeated google.protobuf.Timestamp future_action_times = 6;
+
+    // Size of the schedule's internal state (including payloads) in bytes.
+    int64 state_size_bytes = 7;
 }
 
 // ScheduleListEntry is returned by ListSchedules.


### PR DESCRIPTION
**What changed?**
- Added `state_size_bytes` to scheduler structs

**Why?**
- Needed by metering validation pipelines, potentially useful to customers interested in storage costs
- Same pattern as in SAA

**Breaking changes**
- New fields only
