### PR TITLE
add sdk name and version to ActivityExecutionInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13322,6 +13322,14 @@
           "type": "string",
           "format": "int64",
           "description": "Total number of heartbeats recorded across all attempts of this activity, including retries."
+        },
+        "sdkName": {
+          "type": "string",
+          "description": "The name of the SDK of the worker that most recently picked up an attempt of this activity.\nOverwritten on each new attempt. Empty if unknown."
+        },
+        "sdkVersion": {
+          "type": "string",
+          "description": "The version of the SDK of the worker that most recently picked up an attempt of this activity.\nOverwritten on each new attempt. Empty if unknown."
         }
       },
       "description": "Information about a standalone activity."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9732,6 +9732,16 @@ components:
         totalHeartbeatCount:
           type: string
           description: Total number of heartbeats recorded across all attempts of this activity, including retries.
+        sdkName:
+          type: string
+          description: |-
+            The name of the SDK of the worker that most recently picked up an attempt of this activity.
+             Overwritten on each new attempt. Empty if unknown.
+        sdkVersion:
+          type: string
+          description: |-
+            The version of the SDK of the worker that most recently picked up an attempt of this activity.
+             Overwritten on each new attempt. Empty if unknown.
       description: Information about a standalone activity.
     ActivityExecutionListInfo:
       type: object

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -168,6 +168,14 @@ message ActivityExecutionInfo {
 
     // Total number of heartbeats recorded across all attempts of this activity, including retries.
     int64 total_heartbeat_count = 34;
+
+    // The name of the SDK of the worker that most recently picked up an attempt of this activity.
+    // Overwritten on each new attempt. Empty if unknown.
+    string sdk_name = 35;
+
+    // The version of the SDK of the worker that most recently picked up an attempt of this activity.
+    // Overwritten on each new attempt. Empty if unknown.
+    string sdk_version = 36;
 }
 
 // Limited activity information returned in the list response.


### PR DESCRIPTION
**What changed?**
Added two new fields to ActivityExecutionInfo in temporal/api/activity/v1/message.proto:                                                 
  - sdk_name (field 35) — name of the SDK of the worker that most recently picked up an attempt of the activity
  - sdk_version (field 36) — corresponding SDK version

**Why?**
Standalone Activities have no way to expose which SDK ran a given attempt. Workflows already expose this info; this PR adds the public API surface so DescribeActivityExecution can return the same info.
