### PR TITLE
ShutdownWorker: Consolidate task_queue fields into single repeated field

### DIFF
--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1109,6 +1109,11 @@ message ResetStickyTaskQueueResponse {
 }
 
 message ShutdownWorkerRequest {
+    message WorkerPollerTaskQueue {
+        string name = 1;
+        temporal.api.enums.v1.TaskQueueType type = 2;
+    }
+
     string namespace = 1;
     // sticky_task_queue may not always be populated. We want to ensure all workers
     // send a shutdown request to update worker state for heartbeating, as well
@@ -1127,13 +1132,13 @@ message ShutdownWorkerRequest {
     string task_queue = 7 [deprecated = true];
     // Task queue types that help server cancel outstanding poll RPC
     // calls from SDK. This avoids a race condition that can lead to tasks being lost.
-    repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 8;
-    // Task queue names the worker is polling on. This allows server to cancel
+    repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 8 [deprecated = true];
+    // Task queues the worker is polling on. This allows server to cancel
     // all outstanding poll RPC calls from SDK. This avoids a race condition that
-    // can lead to tasks being lost. This list of task queues potentially contains
-    // the regular task queue, the sticky task queue, and the 2 internal task
-    // queues that Go sessions use.
-    repeated string task_queues = 9;
+    // can lead to tasks being lost. Each entry identifies a specific task queue
+    // name and type pair, allowing the same task queue name to appear multiple
+    // times for workers polling more than one task queue type.
+    repeated WorkerPollerTaskQueue task_queues = 9;
 }
 
 message ShutdownWorkerResponse {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1113,7 +1113,7 @@ message ShutdownWorkerRequest {
     // sticky_task_queue may not always be populated. We want to ensure all workers
     // send a shutdown request to update worker state for heartbeating, as well
     // as cancel pending poll calls early, instead of waiting for timeouts.
-    string sticky_task_queue = 2;
+    string sticky_task_queue = 2 [deprecated = true];
     string identity = 3;
     string reason = 4;
     temporal.api.worker.v1.WorkerHeartbeat worker_heartbeat = 5;
@@ -1124,10 +1124,16 @@ message ShutdownWorkerRequest {
     // Task queue name the worker is polling on. This allows server to cancel
     // all outstanding poll RPC calls from SDK. This avoids a race condition that
     // can lead to tasks being lost.
-    string task_queue = 7;
+    string task_queue = 7 [deprecated = true];
     // Task queue types that help server cancel outstanding poll RPC
     // calls from SDK. This avoids a race condition that can lead to tasks being lost.
     repeated temporal.api.enums.v1.TaskQueueType task_queue_types = 8;
+    // Task queue names the worker is polling on. This allows server to cancel
+    // all outstanding poll RPC calls from SDK. This avoids a race condition that
+    // can lead to tasks being lost. This list of task queues potentially contains
+    // the regular task queue, the sticky task queue, and the 2 internal task
+    // queues that Go sessions use.
+    repeated string task_queues = 9;
 }
 
 message ShutdownWorkerResponse {


### PR DESCRIPTION
**What changed?**
Consolidated task_queue and sticky_task_queue fields into single `task_queues` field


<!-- Tell your future self why have you made these changes -->
**Why?**
Need to add support for Go Sessions, which polls on 2 separate internal task queues, easiest way is to just have a single repeated `task_queues` field that we can encapsulate, also making things easier in case we ever add even more task queues


<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
