### PR TITLE
Add optional activity outcome in start activity response

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -18950,7 +18950,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "The run ID of the activity that was started - or used (via ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING)."
+          "description": "The run ID of the activity that was started - or used (via ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING),\nor was already completed when request's id_reuse_policy_return_existing_outcome_on_reject\ncauses an outcome to be included in this response."
         },
         "started": {
           "type": "boolean",
@@ -18958,11 +18958,11 @@
         },
         "link": {
           "$ref": "#/definitions/v1Link",
-          "description": "Link to the started activity."
+          "description": "Link to the started activity - or an already completed activity when request's\nid_reuse_policy_return_existing_outcome_on_reject causes an outcome to be included in this."
         },
         "outcome": {
           "$ref": "#/definitions/v1ActivityExecutionOutcome",
-          "description": "Only set if the activity is already completed and include_outcome was true in the request."
+          "description": "Only set if the activity is already completed and id_reuse_policy_return_existing_outcome_on_reject\nwas true in the request. In that case it also populates the run_id and link for that activity."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12174,9 +12174,9 @@
           "type": "string",
           "description": "Time to wait before dispatching the first activity task. This delay is not applied to retry attempts."
         },
-        "includeOutcome": {
+        "idReusePolicyReturnExistingOutcomeOnReject": {
           "type": "boolean",
-          "description": "Include the outcome in a success response if the activity has completed, and\nid_reuse_policy or id_conflict_policy would have caused a failure response otherwise.\nThis is applicable only when the id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE,\nor the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,\nor id_conflict_policy is ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING."
+          "description": "Include the outcome in a success response if the activity has completed, and\nid_reuse_policy would have caused a failure response otherwise.\nThis is applicable only when the id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE,\nor the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12176,7 +12176,7 @@
         },
         "includeOutcome": {
           "type": "boolean",
-          "description": "Include the outcome (result/failure) in the response if the activity has completed."
+          "description": "Include the outcome in the response if the activity has completed."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12176,7 +12176,7 @@
         },
         "includeOutcome": {
           "type": "boolean",
-          "description": "Include the outcome in the response if the activity has completed."
+          "description": "Include the outcome in a success response if the activity has completed, and\nid_reuse_policy or id_conflict_policy would have caused a failure response otherwise.\nThis is applicable only when the id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE,\nor the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,\nor id_conflict_policy is ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12173,6 +12173,10 @@
         "startDelay": {
           "type": "string",
           "description": "Time to wait before dispatching the first activity task. This delay is not applied to retry attempts."
+        },
+        "includeOutcome": {
+          "type": "boolean",
+          "description": "Include the outcome (result/failure) in the response if the activity has completed."
         }
       }
     },
@@ -18929,6 +18933,10 @@
         "link": {
           "$ref": "#/definitions/v1Link",
           "description": "Link to the started activity."
+        },
+        "outcome": {
+          "$ref": "#/definitions/v1ActivityExecutionOutcome",
+          "description": "Only set if the activity is already completed and include_outcome was true in the request."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16349,6 +16349,9 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+        includeOutcome:
+          type: boolean
+          description: Include the outcome (result/failure) in the response if the activity has completed.
     StartActivityExecutionResponse:
       type: object
       properties:
@@ -16362,6 +16365,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/Link'
           description: Link to the started activity.
+        outcome:
+          allOf:
+            - $ref: '#/components/schemas/ActivityExecutionOutcome'
+          description: Only set if the activity is already completed and include_outcome was true in the request.
     StartBatchOperationRequest:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16377,14 +16377,13 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
-        includeOutcome:
+        idReusePolicyReturnExistingOutcomeOnReject:
           type: boolean
           description: |-
             Include the outcome in a success response if the activity has completed, and
-             id_reuse_policy or id_conflict_policy would have caused a failure response otherwise.
+             id_reuse_policy would have caused a failure response otherwise.
              This is applicable only when the id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE,
-             or the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-             or id_conflict_policy is ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
+             or the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY.
     StartActivityExecutionResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16389,18 +16389,25 @@ components:
       properties:
         runId:
           type: string
-          description: The run ID of the activity that was started - or used (via ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING).
+          description: |-
+            The run ID of the activity that was started - or used (via ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING),
+             or was already completed when request's id_reuse_policy_return_existing_outcome_on_reject
+             causes an outcome to be included in this response.
         started:
           type: boolean
           description: If true, a new activity was started.
         link:
           allOf:
             - $ref: '#/components/schemas/Link'
-          description: Link to the started activity.
+          description: |-
+            Link to the started activity - or an already completed activity when request's
+             id_reuse_policy_return_existing_outcome_on_reject causes an outcome to be included in this.
         outcome:
           allOf:
             - $ref: '#/components/schemas/ActivityExecutionOutcome'
-          description: Only set if the activity is already completed and include_outcome was true in the request.
+          description: |-
+            Only set if the activity is already completed and id_reuse_policy_return_existing_outcome_on_reject
+             was true in the request. In that case it also populates the run_id and link for that activity.
     StartBatchOperationRequest:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16367,7 +16367,7 @@ components:
           description: Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
         includeOutcome:
           type: boolean
-          description: Include the outcome (result/failure) in the response if the activity has completed.
+          description: Include the outcome in the response if the activity has completed.
     StartActivityExecutionResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16379,7 +16379,12 @@ components:
           description: Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
         includeOutcome:
           type: boolean
-          description: Include the outcome in the response if the activity has completed.
+          description: |-
+            Include the outcome in a success response if the activity has completed, and
+             id_reuse_policy or id_conflict_policy would have caused a failure response otherwise.
+             This is applicable only when the id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE,
+             or the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+             or id_conflict_policy is ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
     StartActivityExecutionResponse:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3165,7 +3165,7 @@ message StartActivityExecutionRequest {
     // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
     google.protobuf.Duration start_delay = 22;
 
-    // Include the outcome (result/failure) in the response if the activity has completed.
+    // Include the outcome in the response if the activity has completed.
     bool include_outcome = 23;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3165,7 +3165,11 @@ message StartActivityExecutionRequest {
     // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
     google.protobuf.Duration start_delay = 22;
 
-    // Include the outcome in the response if the activity has completed.
+    // Include the outcome in a success response if the activity has completed, and
+    // id_reuse_policy or id_conflict_policy would have caused a failure response otherwise.
+    // This is applicable only when the id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE,
+    // or the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+    // or id_conflict_policy is ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
     bool include_outcome = 23;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3164,6 +3164,9 @@ message StartActivityExecutionRequest {
     temporal.api.common.v1.OnConflictOptions on_conflict_options = 21;
     // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
     google.protobuf.Duration start_delay = 22;
+
+    // Include the outcome (result/failure) in the response if the activity has completed.
+    bool include_outcome = 23;
 }
 
 message StartActivityExecutionResponse {
@@ -3173,6 +3176,8 @@ message StartActivityExecutionResponse {
     bool started = 2;
     // Link to the started activity.
     temporal.api.common.v1.Link link = 3;
+    // Only set if the activity is already completed and include_outcome was true in the request.
+    temporal.api.activity.v1.ActivityExecutionOutcome outcome = 4;
 }
 
 message DescribeActivityExecutionRequest {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3178,13 +3178,17 @@ message StartActivityExecutionRequest {
 }
 
 message StartActivityExecutionResponse {
-    // The run ID of the activity that was started - or used (via ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING).
+    // The run ID of the activity that was started - or used (via ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING),
+    // or was already completed when request's id_reuse_policy_return_existing_outcome_on_reject
+    // causes an outcome to be included in this response.
     string run_id = 1;
     // If true, a new activity was started.
     bool started = 2;
-    // Link to the started activity.
+    // Link to the started activity - or an already completed activity when request's
+    // id_reuse_policy_return_existing_outcome_on_reject causes an outcome to be included in this.
     temporal.api.common.v1.Link link = 3;
-    // Only set if the activity is already completed and include_outcome was true in the request.
+    // Only set if the activity is already completed and id_reuse_policy_return_existing_outcome_on_reject
+    // was true in the request. In that case it also populates the run_id and link for that activity.
     temporal.api.activity.v1.ActivityExecutionOutcome outcome = 4;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3171,11 +3171,10 @@ message StartActivityExecutionRequest {
     google.protobuf.Duration start_delay = 22;
 
     // Include the outcome in a success response if the activity has completed, and
-    // id_reuse_policy or id_conflict_policy would have caused a failure response otherwise.
+    // id_reuse_policy would have caused a failure response otherwise.
     // This is applicable only when the id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE,
-    // or the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-    // or id_conflict_policy is ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
-    bool include_outcome = 23;
+    // or the activity succeeded and id_reuse_policy is ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY.
+    bool id_reuse_policy_return_existing_outcome_on_reject = 23;
 }
 
 message StartActivityExecutionResponse {


### PR DESCRIPTION
**What changed?**
Added a new outcome field of type ActivityExecutionOutcome in
StartActivityExecutionResponse and a new boolean flag of 
id_reuse_policy_return_existing_outcome_on_reject in
StartActivityExecutionRequest.

**Why?**
So that the outcome is included if the execution is already started,
and the activity is already completed, to avoid another query for
the outcome. When a caller's `StartActivityExecution` short-circuits
to an existing run with the same activity ID because of an ID reuse,
the caller often wants the outcome of the existing run, not just the
identifier or an error pointing at it. Retrieving the outcome in the
response avoids the caller to use a second RPC of 
`DescribeActivityExecution` to retrieve a result that the server
already has cached.

**Breaking changes**
No