### PR TITLE
delete max elasped duration

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -19472,10 +19472,6 @@
         "maxSkippedDuration": {
           "type": "string",
           "description": "Maximum total virtual time that can be skipped."
-        },
-        "maxElapsedDuration": {
-          "type": "string",
-          "description": "Maximum elapsed time since time skipping was enabled.\nThis includes both skipped time and real time elapsing."
         }
       },
       "description": "Configuration for time skipping during a workflow execution.\nWhen enabled, virtual time advances automatically whenever there is no in-flight work.\nIn-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\nand possibly other features added in the future.\nUser timers are not classified as in-flight work and will be skipped over.\nWhen time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n\nPropagation behavior of time skipping:\nThe enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n(1) Child workflows and continue-as-new: both the configuration and the accumulated skipped duration are\n    inherited from the current execution. The configured bound is shared between the inherited skipped\n    duration and any additional duration skipped by the new run.\n(2) Retry and cron: the configuration and accumulated skipped duration are inherited as recorded when the\n    current workflow started; the accumulated skipped duration of the current run is not propagated.\n(3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n    all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n    point, the resulting run ends up with the same final time-skipping configuration as the previous run."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -17238,12 +17238,6 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: Maximum total virtual time that can be skipped.
-        maxElapsedDuration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-          description: |-
-            Maximum elapsed time since time skipping was enabled.
-             This includes both skipped time and real time elapsing.
       description: "Configuration for time skipping during a workflow execution.\n When enabled, virtual time advances automatically whenever there is no in-flight work.\n In-flight work includes activities, child workflows, Nexus operations, signal/cancel external workflow operations,\n and possibly other features added in the future.\n User timers are not classified as in-flight work and will be skipped over.\n When time advances, it skips to the earlier of the next user timer or the configured bound, if either exists.\n \n Propagation behavior of time skipping:\n The enabled flag, bound fields, and accumulated skipped duration are propagated to related executions as follows:\n (1) Child workflows and continue-as-new: both the configuration and the accumulated skipped duration are\n     inherited from the current execution. The configured bound is shared between the inherited skipped\n     duration and any additional duration skipped by the new run.\n (2) Retry and cron: the configuration and accumulated skipped duration are inherited as recorded when the\n     current workflow started; the accumulated skipped duration of the current run is not propagated.\n (3) Reset: the new run retains the time-skipping configuration of the current execution. Because reset replays\n     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that\n     point, the resulting run ends up with the same final time-skipping configuration as the previous run."
     TimeoutFailureInfo:
       type: object

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -609,8 +609,8 @@ message WorkflowExecutionOptions {
 //     all events up to the reset point and re-applies any UpdateWorkflowExecutionOptions changes made after that
 //     point, the resulting run ends up with the same final time-skipping configuration as the previous run.
 message TimeSkippingConfig {
-    reserved 2, 6;
-    reserved "disable_propagation", "max_target_time";
+    reserved 2, 5, 6;
+    reserved "disable_propagation", "max_elapsed_duration", "max_target_time";
 
     // Enables or disables time skipping for this workflow execution.
     bool enabled = 1;
@@ -625,11 +625,6 @@ message TimeSkippingConfig {
     oneof bound {
         // Maximum total virtual time that can be skipped.
         google.protobuf.Duration max_skipped_duration = 4;
-
-        // Maximum elapsed time since time skipping was enabled.
-        // This includes both skipped time and real time elapsing.
-        // (-- api-linter: core::0142::time-field-names=disabled --)
-        google.protobuf.Duration max_elapsed_duration = 5;
     }
 }
 


### PR DESCRIPTION
**What changed?**
delete max_elapsed_duration still in a compatible way in this pr

**Why?**
1. we deem this this feature is not necessary given we already have max_skip_duration and its variation in duration calculation adds comprehension efforts than given customers real benefits
2. this feature also complicates server side implementation to a higher level

**Breaking changes**
this feature is already implemented and merged in server as this project is huge we merge it feature by feature, so this api should be merged only after the corresponding server pr to delete it merged

**Server PR**
https://github.com/temporalio/temporal/pull/10387