### PR TITLE
fix: use fully qualified name for nexus services

### DIFF
--- a/cmd/protoc-gen-nexus-rpc-yaml/generator.go
+++ b/cmd/protoc-gen-nexus-rpc-yaml/generator.go
@@ -118,7 +118,7 @@ func generate(gen *protogen.Plugin) error {
 				if !shouldIncludeOperation(p, m) {
 					continue
 				}
-				svcName := string(svc.Desc.Name())
+				svcName := string(svc.Desc.FullName())
 				methodName := string(m.Desc.Name())
 				hasOps = true
 				addOperation(langsDoc, svcName, methodName,

--- a/nexus/temporal-proto-models-nexusrpc.yaml
+++ b/nexus/temporal-proto-models-nexusrpc.yaml
@@ -1,6 +1,6 @@
 nexusrpc: 1.0.0
 services:
-  WorkflowService:
+  temporal.api.workflowservice.v1.WorkflowService:
     operations:
       SignalWithStartWorkflowExecution:
         input:


### PR DESCRIPTION
**What changed?**
Use the fully qualified name for nexus YAML spec

**Why?**
The service name should be the fully qualified name in case of future clashes on service names.

**Breaking changes**
NA

**Server PR**
NA