### PR TITLE
Add include_heartbeat_details and include_last_failure to DescribeActivityExecutionRequest

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -440,6 +440,20 @@
             "required": false,
             "type": "string",
             "format": "byte"
+          },
+          {
+            "name": "includeHeartbeatDetails",
+            "description": "Include the heartbeat_details field inside info in the response if available.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "includeLastFailure",
+            "description": "Include the last_failure field inside info in the response if available.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -5985,6 +5999,20 @@
             "required": false,
             "type": "string",
             "format": "byte"
+          },
+          {
+            "name": "includeHeartbeatDetails",
+            "description": "Include the heartbeat_details field inside info in the response if available.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "includeLastFailure",
+            "description": "Include the last_failure field inside info in the response if available.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -13221,7 +13249,7 @@
         },
         "heartbeatDetails": {
           "$ref": "#/definitions/v1Payloads",
-          "description": "Details provided in the last recorded activity heartbeat."
+          "description": "Details provided in the last recorded activity heartbeat.\nDescribeActivityExecution does not set this field unless include_heartbeat_details was true in the request."
         },
         "lastHeartbeatTime": {
           "type": "string",
@@ -13259,7 +13287,7 @@
         },
         "lastFailure": {
           "$ref": "#/definitions/v1Failure",
-          "description": "Failure details from the last failed attempt."
+          "description": "Failure details from the last failed attempt.\nDescribeActivityExecution does not set this field unless include_last_failure was true in the request."
         },
         "lastWorkerIdentity": {
           "type": "string"
@@ -14926,7 +14954,7 @@
         },
         "info": {
           "$ref": "#/definitions/v1ActivityExecutionInfo",
-          "description": "Information about the activity execution."
+          "description": "Information about the activity execution. Fields heartbeat_details and last_failure are omitted unless\nthe request has include_heartbeat_details or include_last_failure set to true, respectively."
         },
         "input": {
           "$ref": "#/definitions/v1Payloads",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -406,6 +406,16 @@ paths:
           schema:
             type: string
             format: bytes
+        - name: includeHeartbeatDetails
+          in: query
+          description: Include the heartbeat_details field inside info in the response if available.
+          schema:
+            type: boolean
+        - name: includeLastFailure
+          in: query
+          description: Include the last_failure field inside info in the response if available.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -5411,6 +5421,16 @@ paths:
           schema:
             type: string
             format: bytes
+        - name: includeHeartbeatDetails
+          in: query
+          description: Include the heartbeat_details field inside info in the response if available.
+          schema:
+            type: boolean
+        - name: includeLastFailure
+          in: query
+          description: Include the last_failure field inside info in the response if available.
+          schema:
+            type: boolean
       responses:
         "200":
           description: OK
@@ -9646,7 +9666,9 @@ components:
         heartbeatDetails:
           allOf:
             - $ref: '#/components/schemas/Payloads'
-          description: Details provided in the last recorded activity heartbeat.
+          description: |-
+            Details provided in the last recorded activity heartbeat.
+             DescribeActivityExecution does not set this field unless include_heartbeat_details was true in the request.
         lastHeartbeatTime:
           type: string
           description: Time the last heartbeat was recorded.
@@ -9678,7 +9700,9 @@ components:
         lastFailure:
           allOf:
             - $ref: '#/components/schemas/Failure'
-          description: Failure details from the last failed attempt.
+          description: |-
+            Failure details from the last failed attempt.
+             DescribeActivityExecution does not set this field unless include_last_failure was true in the request.
         lastWorkerIdentity:
           type: string
         currentRetryInterval:
@@ -11429,7 +11453,9 @@ components:
         info:
           allOf:
             - $ref: '#/components/schemas/ActivityExecutionInfo'
-          description: Information about the activity execution.
+          description: |-
+            Information about the activity execution. Fields heartbeat_details and last_failure are omitted unless
+             the request has include_heartbeat_details or include_last_failure set to true, respectively.
         input:
           allOf:
             - $ref: '#/components/schemas/Payloads'

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -107,6 +107,7 @@ message ActivityExecutionInfo {
     temporal.api.common.v1.RetryPolicy retry_policy = 11;
 
     // Details provided in the last recorded activity heartbeat.
+    // DescribeActivityExecution does not set this field unless include_heartbeat_details was true in the request.
     temporal.api.common.v1.Payloads heartbeat_details = 12;
     // Time the last heartbeat was recorded.
     google.protobuf.Timestamp last_heartbeat_time = 13;
@@ -124,6 +125,7 @@ message ActivityExecutionInfo {
     google.protobuf.Timestamp close_time = 19;
 
     // Failure details from the last failed attempt.
+    // DescribeActivityExecution does not set this field unless include_last_failure was true in the request.
     temporal.api.failure.v1.Failure last_failure = 20;
     string last_worker_identity = 21;
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3196,13 +3196,18 @@ message DescribeActivityExecutionRequest {
     // guaranteed that a client making a sequence of long-poll requests will see a complete
     // sequence of state changes.
     bytes long_poll_token = 6;
+    // Include the heartbeat_details field inside info in the response if available.
+    bool include_heartbeat_details = 7;
+    // Include the last_failure field inside info in the response if available.
+    bool include_last_failure = 8;
 }
 
 message DescribeActivityExecutionResponse {
     // The run ID of the activity, useful when run_id was not specified in the request.
     string run_id = 1;
 
-    // Information about the activity execution.
+    // Information about the activity execution. Fields heartbeat_details and last_failure are omitted unless
+    // the request has include_heartbeat_details or include_last_failure set to true, respectively.
     temporal.api.activity.v1.ActivityExecutionInfo info = 2;
 
     // Serialized activity input, passed as arguments to the activity function.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added `include_heartbeat_details` and `include_last_failure` to `DescribeActivityExecutionRequest`. The intention is that by default, `ActivityExecutionInfo` will omit `heartbeat_details` and `last_failure`.

<!-- Tell your future self why have you made these changes -->
**Why?**
`heartbeat_details` and `last_failure` are user-controlled payloads and potentially very large. These changes allow sending these payloads only when specifically requested, reducing message size when they aren't needed.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
This PR changes what the default behavior of `DescribeActivityExecution` should be. The old behavior is equivalent to setting both `include_heartbeat_details` and `include_last_failure` to true. The server does not need to be immediately updated since the current implementation is functional with new API - however, once server implements the new API, old clients will break if they rely on the old behavior. Note that SAA APIs are in Public Preview and breaking changes can happen.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
TBD