### PR TITLE
Add Event Groups

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -10715,6 +10715,25 @@
       },
       "description": "Target a worker polling on a Nexus task queue in a specific namespace."
     },
+    "EventGroupMarkerInboundEvent": {
+      "type": "object",
+      "properties": {
+        "inboundEventId": {
+          "type": "string",
+          "format": "int64"
+        }
+      },
+      "description": "The event ID of an event in the present workflow that triggered implicit\ncreation of this group Marker.\n\nThe target event's type must be one of the following:\n - `WORKFLOW_EXECUTION_STARTED`\n - `WORKFLOW_EXECUTION_SIGNALED`"
+    },
+    "EventGroupMarkerInboundUpdate": {
+      "type": "object",
+      "properties": {
+        "inboundUpdateId": {
+          "type": "string"
+        }
+      },
+      "description": "The identifier of an inbound Update (request.meta.update_id)\nwhose handler triggered implicit creation of this group Marker.\n\nUsed in place of `inbound_event_id` for Updates because the event ID of the\nUpdateAccepted history event is not known until the Workflow Task is\ncompleted and recorded by the server, which may be too late."
+    },
     "LinkActivity": {
       "type": "object",
       "properties": {
@@ -15319,6 +15338,34 @@
       },
       "description": "Target to route requests to."
     },
+    "v1EventGroupMarker": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "$ref": "#/definitions/v1EventGroupMarkerLabel"
+        },
+        "inboundEvent": {
+          "$ref": "#/definitions/EventGroupMarkerInboundEvent"
+        },
+        "inboundUpdate": {
+          "$ref": "#/definitions/EventGroupMarkerInboundUpdate"
+        }
+      }
+    },
+    "v1EventGroupMarkerLabel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier assigned by the SDK."
+        },
+        "label": {
+          "$ref": "#/definitions/v1Payload",
+          "description": "This payload should be a \"json/plain\"-encoded payload that is a single\nJSON string for use in user interfaces. User interface formatting may not\napply to this text when used in \"label\" situations. The payload data\nsection is limited to 400 bytes by default.\n\nPayload only needs to be set on the first use of a given Marker ID;\nfurther references to an existing Marker ID reuse existing attributes of\nthe referenced Marker -- i.e. further label payloads are ignored.\n\nNote that it is valid to have distinct Markers (i.e. distinct Marker IDs)\nin a given workflow execution that carry the same label, provided that\nthey have the distinct ID."
+        }
+      },
+      "description": "A user-defined short-form string value to be used as the group's label."
+    },
     "v1EventType": {
       "type": "string",
       "enum": [
@@ -15810,6 +15857,14 @@
         "principal": {
           "$ref": "#/definitions/v1Principal",
           "description": "Server-computed authenticated caller identity associated with this event."
+        },
+        "eventGroupMarkers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1EventGroupMarker"
+          },
+          "description": "Event group markers attached to this event."
         },
         "workflowExecutionStartedEventAttributes": {
           "$ref": "#/definitions/v1WorkflowExecutionStartedEventAttributes"

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -11840,6 +11840,62 @@ components:
           type: string
           description: Nexus task queue to route requests to.
       description: Target a worker polling on a Nexus task queue in a specific namespace.
+    EventGroupMarker:
+      type: object
+      properties:
+        label:
+          $ref: '#/components/schemas/EventGroupMarker_Label'
+        inboundEvent:
+          $ref: '#/components/schemas/EventGroupMarker_InboundEvent'
+        inboundUpdate:
+          $ref: '#/components/schemas/EventGroupMarker_InboundUpdate'
+    EventGroupMarker_InboundEvent:
+      type: object
+      properties:
+        inboundEventId:
+          type: string
+      description: |-
+        The event ID of an event in the present workflow that triggered implicit
+         creation of this group Marker.
+
+         The target event's type must be one of the following:
+          - `WORKFLOW_EXECUTION_STARTED`
+          - `WORKFLOW_EXECUTION_SIGNALED`
+    EventGroupMarker_InboundUpdate:
+      type: object
+      properties:
+        inboundUpdateId:
+          type: string
+      description: |-
+        The identifier of an inbound Update (request.meta.update_id)
+         whose handler triggered implicit creation of this group Marker.
+
+         Used in place of `inbound_event_id` for Updates because the event ID of the
+         UpdateAccepted history event is not known until the Workflow Task is
+         completed and recorded by the server, which may be too late.
+    EventGroupMarker_Label:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Opaque identifier assigned by the SDK.
+        label:
+          allOf:
+            - $ref: '#/components/schemas/Payload'
+          description: |-
+            This payload should be a "json/plain"-encoded payload that is a single
+             JSON string for use in user interfaces. User interface formatting may not
+             apply to this text when used in "label" situations. The payload data
+             section is limited to 400 bytes by default.
+
+             Payload only needs to be set on the first use of a given Marker ID;
+             further references to an existing Marker ID reuse existing attributes of
+             the referenced Marker -- i.e. further label payloads are ignored.
+
+             Note that it is valid to have distinct Markers (i.e. distinct Marker IDs)
+             in a given workflow execution that carry the same label, provided that
+             they have the distinct ID.
+      description: A user-defined short-form string value to be used as the group's label.
     ExternalWorkflowExecutionCancelRequestedEventAttributes:
       type: object
       properties:
@@ -12308,6 +12364,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/Principal'
           description: Server-computed authenticated caller identity associated with this event.
+        eventGroupMarkers:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventGroupMarker'
+          description: Event group markers attached to this event.
         workflowExecutionStartedEventAttributes:
           $ref: '#/components/schemas/WorkflowExecutionStartedEventAttributes'
         workflowExecutionCompletedEventAttributes:

--- a/temporal/api/command/v1/message.proto
+++ b/temporal/api/command/v1/message.proto
@@ -17,6 +17,7 @@ import "temporal/api/common/v1/message.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/taskqueue/v1/message.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
+import "temporal/api/sdk/v1/event_group_marker.proto";
 
 message ScheduleActivityTaskCommandAttributes {
     string activity_id = 1;
@@ -294,6 +295,10 @@ message Command {
     //  * start_timer_command_attributes - populates temporal.api.history.v1.HistoryEvent for timer
     //    started where the summary is used to identify the timer.
     temporal.api.sdk.v1.UserMetadata user_metadata = 301;
+
+    // Event Group Markers attached to the command by the workflow author.
+    repeated temporal.api.sdk.v1.EventGroupMarker event_group_markers = 302;
+
     // The command details. The type must match that in `command_type`.
     oneof attributes {
         ScheduleActivityTaskCommandAttributes schedule_activity_task_command_attributes = 2;

--- a/temporal/api/history/v1/message.proto
+++ b/temporal/api/history/v1/message.proto
@@ -24,6 +24,7 @@ import "temporal/api/update/v1/message.proto";
 import "temporal/api/workflow/v1/message.proto";
 import "temporal/api/sdk/v1/task_complete_metadata.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
+import "temporal/api/sdk/v1/event_group_marker.proto";
 
 // Always the first event in workflow history
 message WorkflowExecutionStartedEventAttributes {
@@ -1193,6 +1194,8 @@ message HistoryEvent {
     repeated temporal.api.common.v1.Link links = 302;
     // Server-computed authenticated caller identity associated with this event.
     temporal.api.common.v1.Principal principal = 303;
+    // Event group markers attached to this event.
+    repeated temporal.api.sdk.v1.EventGroupMarker event_group_markers = 304;
     // The event details. The type must match that in `event_type`.
     oneof attributes {
         WorkflowExecutionStartedEventAttributes workflow_execution_started_event_attributes = 6;

--- a/temporal/api/sdk/v1/event_group_marker.proto
+++ b/temporal/api/sdk/v1/event_group_marker.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package temporal.api.sdk.v1;
+
+option go_package = "go.temporal.io/api/sdk/v1;sdk";
+option java_package = "io.temporal.api.sdk.v1";
+option java_multiple_files = true;
+option java_outer_classname = "EventGroupMarkerProto";
+option ruby_package = "Temporalio::Api::Sdk::V1";
+option csharp_namespace = "Temporalio.Api.Sdk.V1";
+
+
+import "temporal/api/common/v1/message.proto";
+
+message EventGroupMarker {
+  // What this Marker represents. The variant determines whether the Marker was
+  // created explicitly by user code (label) or implicitly by the SDK on inbound
+  // signals/events (inbound_event) or update handlers (inbound_update).
+  oneof variant {
+    Label label = 1;
+    InboundEvent inbound_event = 2;
+    InboundUpdate inbound_update = 3;
+  }
+
+  // A user-defined short-form string value to be used as the group's label.
+  message Label {
+    // Opaque identifier assigned by the SDK.
+    string id = 1;
+
+    // This payload should be a "json/plain"-encoded payload that is a single
+    // JSON string for use in user interfaces. User interface formatting may not
+    // apply to this text when used in "label" situations. The payload data
+    // section is limited to 400 bytes by default.
+    //
+    // Payload only needs to be set on the first use of a given Marker ID;
+    // further references to an existing Marker ID reuse existing attributes of
+    // the referenced Marker -- i.e. further label payloads are ignored.
+    //
+    // Note that it is valid to have distinct Markers (i.e. distinct Marker IDs)
+    // in a given workflow execution that carry the same label, provided that
+    // they have the distinct ID.
+    temporal.api.common.v1.Payload label = 2;
+  }
+
+  // The event ID of an event in the present workflow that triggered implicit
+  // creation of this group Marker.
+  //
+  // The target event's type must be one of the following:
+  //  - `WORKFLOW_EXECUTION_STARTED`
+  //  - `WORKFLOW_EXECUTION_SIGNALED`
+  message InboundEvent {
+    int64 inbound_event_id = 1;
+  }
+
+  // The identifier of an inbound Update (request.meta.update_id)
+  // whose handler triggered implicit creation of this group Marker.
+  //
+  // Used in place of `inbound_event_id` for Updates because the event ID of the
+  // UpdateAccepted history event is not known until the Workflow Task is
+  // completed and recorded by the server, which may be too late.
+  message InboundUpdate {
+    string inbound_update_id = 1;
+  }
+}


### PR DESCRIPTION
**What changed?**

- Introduce the `temporal.api.sdk.v1.EventGroupMarker` message.
- Add `event_group_markers` on `Command` and `HistoryEvent`.

**Why?**

Event Groups is a new form of metadata that allows regrouping of logically related Workflow Events, according to user-defined or system-inferred criteria, providing users with improved visibility, analysis, and debugging capabilities.

**Breaking changes**

No.

**Server PR**

https://github.com/temporalio/temporal/pull/10472