### PR TITLE
add start_delay to ActivityExecutionInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13358,6 +13358,10 @@
         "sdkVersion": {
           "type": "string",
           "description": "The version of the SDK of the worker that most recently picked up an attempt of this activity.\nOverwritten on each new attempt. Empty if unknown."
+        },
+        "startDelay": {
+          "type": "string",
+          "description": "Time to wait before dispatching the first activity task. This delay is not applied to retry attempts."
         }
       },
       "description": "Information about a standalone activity."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9770,6 +9770,10 @@ components:
           description: |-
             The version of the SDK of the worker that most recently picked up an attempt of this activity.
              Overwritten on each new attempt. Empty if unknown.
+        startDelay:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
       description: Information about a standalone activity.
     ActivityExecutionListInfo:
       type: object

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -178,6 +178,9 @@ message ActivityExecutionInfo {
     // The version of the SDK of the worker that most recently picked up an attempt of this activity.
     // Overwritten on each new attempt. Empty if unknown.
     string sdk_version = 36;
+
+    // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+    google.protobuf.Duration start_delay = 37;
 }
 
 // Limited activity information returned in the list response.


### PR DESCRIPTION
**What changed?**
Added a start_delay field to ActivityExecutionInfo 

**Why?**
DescribeActivityExecutionResponse had no way to show the configured start delay back to callers. Putting it on ActivityExecutionInfo keeps it alongside the other configured values and makes it explicit to callers what it was set to during start or update.
