### PR TITLE
Add server_scaled_provider_cloud_run capability

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -15827,6 +15827,10 @@
         "serverScaledDeployments": {
           "type": "boolean",
           "description": "True if the server supports server-scaled deployments.\nThis flag is dependent both on server version and for server-scaled deployments\nto be enabled via server configuration."
+        },
+        "serverScaledProviderCloudRun": {
+          "type": "boolean",
+          "description": "True if the server supports the Cloud Run compute provider for\nserver-scaled deployments. Dependent on server version and the\nprovider being enabled via server configuration."
         }
       },
       "description": "System capability details."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -12260,6 +12260,12 @@ components:
             True if the server supports server-scaled deployments.
              This flag is dependent both on server version and for server-scaled deployments
              to be enabled via server configuration.
+        serverScaledProviderCloudRun:
+          type: boolean
+          description: |-
+            True if the server supports the Cloud Run compute provider for
+             server-scaled deployments. Dependent on server version and the
+             provider being enabled via server configuration.
       description: System capability details.
     GetWorkerBuildIdCompatibilityResponse:
       type: object

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1343,6 +1343,11 @@ message GetSystemInfoResponse {
         // to be enabled via server configuration.
         bool server_scaled_deployments = 12;
 
+        // True if the server supports the Cloud Run compute provider for
+        // server-scaled deployments. Dependent on server version and the
+        // provider being enabled via server configuration.
+        bool server_scaled_provider_cloud_run = 13;
+
     }
 }
 


### PR DESCRIPTION
## What changed
Adds `server_scaled_provider_cloud_run = 13` to `GetSystemInfoResponse.Capabilities`, following the `server_scaled_deployments` pattern (#752).

## Why
The Temporal UI shows Google Cloud Run as a compute provider option for server-scaled worker deployments (temporalio/ui#3518), gated behind this capability — disabled with a "Coming Soon" badge until the server advertises support. The server should only set this once the Cloud Run scaling algorithm (worker-set support in temporal-auto-scaled-workers) ships and is enabled via server configuration.