### PR TITLE
Workflow Command Pagination API

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16795,6 +16795,10 @@
         "pollerAutoscalingAutoEnroll": {
           "type": "boolean",
           "description": "When true, workers should use poller autoscaling by default unless explicitly configured otherwise."
+        },
+        "workflowTaskCompletionPagination": {
+          "type": "boolean",
+          "description": "True if the namespace supports pagination of `RespondWorkflowTaskCompleted` request."
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13186,6 +13186,9 @@ components:
         pollerAutoscalingAutoEnroll:
           type: boolean
           description: When true, workers should use poller autoscaling by default unless explicitly configured otherwise.
+        workflowTaskCompletionPagination:
+          type: boolean
+          description: True if the namespace supports pagination of `RespondWorkflowTaskCompleted` request.
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -137,3 +137,9 @@ message NexusOperationExecutionAlreadyStartedFailure {
     string start_request_id = 1;
     string run_id = 2;
 }
+
+// An error indicating that the server lost the buffered pages of a paginated workflow task
+// completion. This is a transient error: the workflow task is still valid, and the client 
+// should resend all pages from page 0 using the same task token.
+message WorkflowTaskCompletionBufferLostFailure {
+}

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -58,6 +58,8 @@ message NamespaceInfo {
         bool workflow_update_callbacks = 12;
         // When true, workers should use poller autoscaling by default unless explicitly configured otherwise.
         bool poller_autoscaling_auto_enroll = 13;
+        // True if the namespace supports pagination of `RespondWorkflowTaskCompleted` request.
+        bool workflow_task_completion_pagination = 14;
     }
 
     // Namespace configured limits

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -424,6 +424,16 @@ message RespondWorkflowTaskCompletedRequest {
     // tasks (e.g. activity cancellation) to this specific worker instance.
     string worker_control_task_queue = 20;
 
+    // 0-indexed page number when the workflow task completion is split across multiple
+    // requests ("pages"). 0 for single-page requests. May only be set to non-zero value
+    // when the namespace capability workflow_task_completion_pagination is true.
+    int32 page_number = 21;
+
+    // True for non-final pages of a paginated workflow task completion. The final page's
+    // `page_number` tells the server how many intermediate pages (0..page_number-1) preceded it.
+    // May only be used when the namespace capability workflow_task_completion_pagination is true.
+    bool intermediate_page = 22;
+
     // SDK capability details.
     message Capabilities {
         // True if the SDK can handle speculative workflow task with command events. If true, the


### PR DESCRIPTION
**What changed?**
Added a paginated workflow task completion API:
- `page_number` and `intermediate_page` fields on `RespondWorkflowTaskCompletedRequest`, letting a workflow task completion be split across multiple "page" requests sharing one task token.
- `workflow_task_completion_pagination` namespace capability flag that SDKs must check before sending paginated requests.
- `WorkflowTaskCompletionBufferLostFailure` signaling the server dropped buffered pages and the client should resend all pages from page 0.

**Why?**
Large workflow task completions can exceed request size limits. Pagination lets workers split a single completion across multiple requests.

**Breaking changes**
None. New fields/messages are additive; pagination is gated behind the namespace capability.

**Server PR**
https://github.com/temporalio/temporal/pull/10880