### PR TITLE
VLN-1461: remediate unpinned-github-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     name: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: '^1.21'
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
       - name: 'Setup jq'
-        uses: dcarbone/install-jq-action@v2
+        uses: dcarbone/install-jq-action@8867ddb4788346d7c22b72ea2e2ffe4d514c7bcb # v2.1.0
       - run: make ci-build
       - name: Fail if the repo is dirty
         run: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,7 +34,7 @@ jobs:
       api_go_commit_sha: ${{ steps.pin_commits.outputs.api_go_commit_sha }}
     steps:
       - name: Checkout api
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
@@ -42,7 +42,7 @@ jobs:
           path: api
 
       - name: Checkout api-go
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: temporalio/api-go
           ref: ${{ github.event.inputs.branch }}
@@ -107,14 +107,14 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.prepare-inputs.outputs.api_commit_sha }}
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/push-to-buf.yml
+++ b/.github/workflows/push-to-buf.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           version: 1.49.0
           token: ${{ secrets.BUF_TEMPORALIO_TOKEN }}

--- a/.github/workflows/trigger-api-go-update.yml
+++ b/.github/workflows/trigger-api-go-update.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/api</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1461">VLN-1461</a></td></tr>
</table>

## Summary

🤠 [Deputy](https://github.com/temporalio/deputy) pinned dependencies to immutable references.

- Total refs: 13
- Pinned refs: 9
- Skipped refs: 4

Changed references:
- `arduino/setup-protoc`: `v2` -> `a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0`
- `dcarbone/install-jq-action`: `v2` -> `8867ddb4788346d7c22b72ea2e2ffe4d514c7bcb # v2.1.0`
- `actions/checkout`: `v4` -> `34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `actions/setup-go`: `v4` -> `7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0`
- `actions/create-github-app-token`: `v1` -> `d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
- `actions/checkout`: `v4` -> `34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `actions/checkout`: `v4` -> `34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `bufbuild/buf-action`: `v1` -> `fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0`
- `actions/create-github-app-token`: `v1` -> `d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix