### PR TITLE
Add poller_autoscaling_auto_enroll namespace capability

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16739,6 +16739,10 @@
         "workflowUpdateCallbacks": {
           "type": "boolean",
           "title": "True if the namespace supports attaching callbacks on workflow updates"
+        },
+        "pollerAutoscalingAutoEnroll": {
+          "type": "boolean",
+          "description": "When true, workers should use poller autoscaling by default unless explicitly configured otherwise."
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13141,6 +13141,9 @@ components:
         workflowUpdateCallbacks:
           type: boolean
           description: True if the namespace supports attaching callbacks on workflow updates
+        pollerAutoscalingAutoEnroll:
+          type: boolean
+          description: When true, workers should use poller autoscaling by default unless explicitly configured otherwise.
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -52,6 +52,8 @@ message NamespaceInfo {
         bool poller_autoscaling = 9;
         // True if the namespace supports worker commands (server-to-worker communication via control queues).
         bool worker_commands = 10;
+        // True if workers in this namespace should automatically use poller autoscaling without explicit opt-in.
+        bool poller_autoscaling_auto_enroll = 11;
     }
 
     // Namespace configured limits

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -56,7 +56,7 @@ message NamespaceInfo {
         bool standalone_nexus_operation = 11;
         // True if the namespace supports attaching callbacks on workflow updates
         bool workflow_update_callbacks = 12;
-        // True if workers in this namespace should automatically use poller autoscaling without explicit opt-in.
+        // When true, workers should use poller autoscaling by default unless explicitly configured otherwise.
         bool poller_autoscaling_auto_enroll = 13;
     }
 


### PR DESCRIPTION
## What
Add a new `poller_autoscaling_auto_enroll` boolean field to `NamespaceInfo.Capabilities`.

## Why
Today, poller autoscaling requires explicit SDK-side opt-in via worker options. This capability lets the server tell SDKs to automatically enroll workers in poller autoscaling for specific namespaces, controlled by a namespace-scoped dynamic config — no user code changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)