### PR TITLE
Add start_delay to ActivityOptions for update support

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13664,7 +13664,7 @@
         },
         "startDelay": {
           "type": "string",
-          "title": "Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.\nWhen updated, the time is added to the original `schedule_time`, not to the current time.\nIf the resulting time is in the past, dispatches immediately"
+          "description": "Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.\nWhen updated, the time is added to the original `schedule_time`, not to the current time.\nIf the resulting time is in the past, the task is made available for dispatch immediately."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12178,7 +12178,7 @@
         },
         "workflowStartDelay": {
           "type": "string",
-          "description": "Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.\nNote that the signal will be delivered with the first workflow task. If the workflow gets\nanother SignalWithStartWorkflow before the delay a workflow task will be dispatched immediately\nand the rest of the delay period will be ignored, even if that request also had a delay.\nSignal via SignalWorkflowExecution will not unblock the workflow."
+          "description": "Time to wait before making the first workflow task available for dispatch. Cannot be used with `cron_schedule`.\nNote that the signal will be delivered with the first workflow task. If the workflow gets\nanother SignalWithStartWorkflow before the delay a workflow task will be made available for dispatch immediately\nand the rest of the delay period will be ignored, even if that request also had a delay.\nSignal via SignalWorkflowExecution will not unblock the workflow."
         },
         "userMetadata": {
           "$ref": "#/definitions/v1UserMetadata",
@@ -12338,7 +12338,7 @@
         },
         "startDelay": {
           "type": "string",
-          "description": "Time to wait before dispatching the first activity task. This delay is not applied to retry attempts."
+          "description": "Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts."
         }
       }
     },
@@ -12530,7 +12530,7 @@
         },
         "workflowStartDelay": {
           "type": "string",
-          "description": "Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.\nIf the workflow gets a signal before the delay, a workflow task will be dispatched and the rest\nof the delay will be ignored."
+          "description": "Time to wait before making the first workflow task available for dispatch. Cannot be used with `cron_schedule`.\nIf the workflow gets a signal before the delay, a workflow task will be made available for dispatch and the rest\nof the delay will be ignored."
         },
         "completionCallbacks": {
           "type": "array",
@@ -13499,7 +13499,7 @@
         },
         "startDelay": {
           "type": "string",
-          "description": "Time to wait before dispatching the first activity task. This delay is not applied to retry attempts."
+          "description": "Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts."
         }
       },
       "description": "Information about a standalone activity."
@@ -13664,7 +13664,7 @@
         },
         "startDelay": {
           "type": "string",
-          "description": "Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.\nWhen updated, anchored to the original `schedule_time`. If the resulting time is in the past, dispatches\nimmediately."
+          "title": "Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.\nWhen updated, the time is added to the original `schedule_time`, not to the current time.\nIf the resulting time is in the past, dispatches immediately"
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13661,6 +13661,10 @@
         "priority": {
           "$ref": "#/definitions/v1Priority",
           "description": "Priority metadata. If this message is not present, or any fields are not\npresent, they inherit the values from the workflow."
+        },
+        "startDelay": {
+          "type": "string",
+          "description": "Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.\nWhen updated, anchored to the original `schedule_time`. If the resulting time is in the past, dispatches\nimmediately."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9997,6 +9997,13 @@ components:
           description: |-
             Priority metadata. If this message is not present, or any fields are not
              present, they inherit the values from the workflow.
+        startDelay:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+          description: |-
+            Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+             When updated, anchored to the original `schedule_time`. If the resulting time is in the past, dispatches
+             immediately.
     ActivityPropertiesModifiedExternallyEventAttributes:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9851,7 +9851,7 @@ components:
         startDelay:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
-          description: Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+          description: Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
       description: Information about a standalone activity.
     ActivityExecutionListInfo:
       type: object
@@ -10001,9 +10001,9 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: |-
-            Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
-             When updated, anchored to the original `schedule_time`. If the resulting time is in the past, dispatches
-             immediately.
+            Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
+             When updated, the time is added to the original `schedule_time`, not to the current time.
+             If the resulting time is in the past, dispatches immediately
     ActivityPropertiesModifiedExternallyEventAttributes:
       type: object
       properties:
@@ -16371,9 +16371,9 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: |-
-            Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
+            Time to wait before making the first workflow task available for dispatch. Cannot be used with `cron_schedule`.
              Note that the signal will be delivered with the first workflow task. If the workflow gets
-             another SignalWithStartWorkflow before the delay a workflow task will be dispatched immediately
+             another SignalWithStartWorkflow before the delay a workflow task will be made available for dispatch immediately
              and the rest of the delay period will be ignored, even if that request also had a delay.
              Signal via SignalWorkflowExecution will not unblock the workflow.
         userMetadata:
@@ -16590,7 +16590,7 @@ components:
         startDelay:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
-          description: Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+          description: Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
     StartActivityExecutionResponse:
       type: object
       properties:
@@ -16979,8 +16979,8 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: |-
-            Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
-             If the workflow gets a signal before the delay, a workflow task will be dispatched and the rest
+            Time to wait before making the first workflow task available for dispatch. Cannot be used with `cron_schedule`.
+             If the workflow gets a signal before the delay, a workflow task will be made available for dispatch and the rest
              of the delay will be ignored.
         completionCallbacks:
           type: array

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10003,7 +10003,7 @@ components:
           description: |-
             Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
              When updated, the time is added to the original `schedule_time`, not to the current time.
-             If the resulting time is in the past, dispatches immediately
+             If the resulting time is in the past, the task is made available for dispatch immediately.
     ActivityPropertiesModifiedExternallyEventAttributes:
       type: object
       properties:

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -63,6 +63,11 @@ message ActivityOptions {
     // Priority metadata. If this message is not present, or any fields are not
     // present, they inherit the values from the workflow.
     temporal.api.common.v1.Priority priority = 7;
+
+    // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+    // When updated, anchored to the original `schedule_time`. If the resulting time is in the past, dispatches
+    // immediately.
+    google.protobuf.Duration start_delay = 8;
 }
 
 // Information about a standalone activity.

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -64,9 +64,9 @@ message ActivityOptions {
     // present, they inherit the values from the workflow.
     temporal.api.common.v1.Priority priority = 7;
 
-    // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
-    // When updated, anchored to the original `schedule_time`. If the resulting time is in the past, dispatches
-    // immediately.
+    // Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
+    // When updated, the time is added to the original `schedule_time`, not to the current time.
+    // If the resulting time is in the past, dispatches immediately
     google.protobuf.Duration start_delay = 8;
 }
 
@@ -184,7 +184,7 @@ message ActivityExecutionInfo {
     // Overwritten on each new attempt. Empty if unknown.
     string sdk_version = 36;
 
-    // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+    // Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
     google.protobuf.Duration start_delay = 37;
 }
 

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -66,7 +66,7 @@ message ActivityOptions {
 
     // Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
     // When updated, the time is added to the original `schedule_time`, not to the current time.
-    // If the resulting time is in the past, dispatches immediately
+    // If the resulting time is in the past, the task is made available for dispatch immediately.
     google.protobuf.Duration start_delay = 8;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -182,8 +182,8 @@ message StartWorkflowExecutionRequest {
     // StartWorkflowExecution.
     temporal.api.failure.v1.Failure continued_failure = 18;
     temporal.api.common.v1.Payloads last_completion_result = 19;
-    // Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
-    // If the workflow gets a signal before the delay, a workflow task will be dispatched and the rest
+    // Time to wait before making the first workflow task available for dispatch. Cannot be used with `cron_schedule`.
+    // If the workflow gets a signal before the delay, a workflow task will be made available for dispatch and the rest
     // of the delay will be ignored.
     google.protobuf.Duration workflow_start_delay = 20;
     // Callbacks to be called by the server when this workflow reaches a terminal state.
@@ -879,9 +879,9 @@ message SignalWithStartWorkflowExecutionRequest {
     temporal.api.common.v1.Memo memo = 17;
     temporal.api.common.v1.SearchAttributes search_attributes = 18;
     temporal.api.common.v1.Header header = 19;
-    // Time to wait before dispatching the first workflow task. Cannot be used with `cron_schedule`.
+    // Time to wait before making the first workflow task available for dispatch. Cannot be used with `cron_schedule`.
     // Note that the signal will be delivered with the first workflow task. If the workflow gets
-    // another SignalWithStartWorkflow before the delay a workflow task will be dispatched immediately
+    // another SignalWithStartWorkflow before the delay a workflow task will be made available for dispatch immediately
     // and the rest of the delay period will be ignored, even if that request also had a delay.
     // Signal via SignalWorkflowExecution will not unblock the workflow.
     google.protobuf.Duration workflow_start_delay = 20;
@@ -3186,7 +3186,7 @@ message StartActivityExecutionRequest {
     repeated temporal.api.common.v1.Link links = 20;
     // Options for handling conflicts when using ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING.
     temporal.api.common.v1.OnConflictOptions on_conflict_options = 21;
-    // Time to wait before dispatching the first activity task. This delay is not applied to retry attempts.
+    // Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
     google.protobuf.Duration start_delay = 22;
 }
 


### PR DESCRIPTION
**What changed?**
Added a start_delay field to the ActivityOptions message in temporal/api/activity/v1/message.proto. OpenAPI specs (v2/v3) were regenerated accordingly.

**Why?**
Expose start_delay through UpdateActivityExecutionOptions so users can modify or zero out the delay on a still-pending standalone activity. The new value is anchored to the activity's original schedule_time, so the field has the same semantics whether set at creation or via update. Server-side implementation lands in a follow-up PR.