### PR TITLE
Add execution_time to activity execution info

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13501,15 +13501,10 @@
           "type": "string",
           "description": "Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts."
         },
-        "requestedStartTime": {
+        "executionTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The time at which the activity is requested to start, computed as `schedule_time + start_delay`.\nSame as `schedule_time` if `start_delay` is not set."
-        },
-        "actualStartTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time at which the activity was first dispatched to a worker (i.e. when a worker first picked\nup the task from matching). Not set until a worker picks up the first attempt. Not updated on\nsubsequent retry attempts."
+          "description": "The time at which the first activity task is made available for dispatch, computed as\n`schedule_time + start_delay`. Same as `schedule_time` if `start_delay` is not set."
         }
       },
       "description": "Information about a standalone activity."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13564,16 +13564,6 @@
         "executionDuration": {
           "type": "string",
           "description": "The difference between close time and scheduled time.\nThis field is only populated if the activity is closed."
-        },
-        "requestedStartTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time at which the activity is requested to start, computed as `schedule_time + start_delay`.\nSame as `schedule_time` if `start_delay` is not set."
-        },
-        "actualStartTime": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The time at which the activity was first dispatched to a worker (i.e. when a worker first picked\nup the task from matching). Not set until a worker picks up the first attempt. Not updated on\nsubsequent retry attempts."
         }
       },
       "description": "Limited activity information returned in the list response.\nWhen adding fields here, ensure that it is also present in ActivityExecutionInfo (note that it\nmay already be present in ActivityExecutionInfo but not at the top-level)."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13500,6 +13500,16 @@
         "startDelay": {
           "type": "string",
           "description": "Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts."
+        },
+        "requestedStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the activity is requested to start, computed as `schedule_time + start_delay`.\nSame as `schedule_time` if `start_delay` is not set."
+        },
+        "actualStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the activity was first dispatched to a worker (i.e. when a worker first picked\nup the task from matching). Not set until a worker picks up the first attempt. Not updated on\nsubsequent retry attempts."
         }
       },
       "description": "Information about a standalone activity."
@@ -13554,6 +13564,16 @@
         "executionDuration": {
           "type": "string",
           "description": "The difference between close time and scheduled time.\nThis field is only populated if the activity is closed."
+        },
+        "requestedStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the activity is requested to start, computed as `schedule_time + start_delay`.\nSame as `schedule_time` if `start_delay` is not set."
+        },
+        "actualStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the activity was first dispatched to a worker (i.e. when a worker first picked\nup the task from matching). Not set until a worker picks up the first attempt. Not updated on\nsubsequent retry attempts."
         }
       },
       "description": "Limited activity information returned in the list response.\nWhen adding fields here, ensure that it is also present in ActivityExecutionInfo (note that it\nmay already be present in ActivityExecutionInfo but not at the top-level)."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9852,18 +9852,11 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
-        requestedStartTime:
+        executionTime:
           type: string
           description: |-
-            The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
-             Same as `schedule_time` if `start_delay` is not set.
-          format: date-time
-        actualStartTime:
-          type: string
-          description: |-
-            The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
-             up the task from matching). Not set until a worker picks up the first attempt. Not updated on
-             subsequent retry attempts.
+            The time at which the first activity task is made available for dispatch, computed as
+             `schedule_time + start_delay`. Same as `schedule_time` if `start_delay` is not set.
           format: date-time
       description: Information about a standalone activity.
     ActivityExecutionListInfo:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9852,6 +9852,19 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
+        requestedStartTime:
+          type: string
+          description: |-
+            The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
+             Same as `schedule_time` if `start_delay` is not set.
+          format: date-time
+        actualStartTime:
+          type: string
+          description: |-
+            The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
+             up the task from matching). Not set until a worker picks up the first attempt. Not updated on
+             subsequent retry attempts.
+          format: date-time
       description: Information about a standalone activity.
     ActivityExecutionListInfo:
       type: object
@@ -9907,6 +9920,19 @@ components:
           description: |-
             The difference between close time and scheduled time.
              This field is only populated if the activity is closed.
+        requestedStartTime:
+          type: string
+          description: |-
+            The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
+             Same as `schedule_time` if `start_delay` is not set.
+          format: date-time
+        actualStartTime:
+          type: string
+          description: |-
+            The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
+             up the task from matching). Not set until a worker picks up the first attempt. Not updated on
+             subsequent retry attempts.
+          format: date-time
       description: |-
         Limited activity information returned in the list response.
          When adding fields here, ensure that it is also present in ActivityExecutionInfo (note that it

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9920,19 +9920,6 @@ components:
           description: |-
             The difference between close time and scheduled time.
              This field is only populated if the activity is closed.
-        requestedStartTime:
-          type: string
-          description: |-
-            The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
-             Same as `schedule_time` if `start_delay` is not set.
-          format: date-time
-        actualStartTime:
-          type: string
-          description: |-
-            The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
-             up the task from matching). Not set until a worker picks up the first attempt. Not updated on
-             subsequent retry attempts.
-          format: date-time
       description: |-
         Limited activity information returned in the list response.
          When adding fields here, ensure that it is also present in ActivityExecutionInfo (note that it

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -186,6 +186,15 @@ message ActivityExecutionInfo {
 
     // Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
     google.protobuf.Duration start_delay = 37;
+
+    // The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
+    // Same as `schedule_time` if `start_delay` is not set.
+    google.protobuf.Timestamp requested_start_time = 38;
+
+    // The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
+    // up the task from matching). Not set until a worker picks up the first attempt. Not updated on
+    // subsequent retry attempts.
+    google.protobuf.Timestamp actual_start_time = 39;
 }
 
 // Limited activity information returned in the list response.
@@ -219,6 +228,15 @@ message ActivityExecutionListInfo {
     // The difference between close time and scheduled time.
     // This field is only populated if the activity is closed.
     google.protobuf.Duration execution_duration = 11;
+
+    // The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
+    // Same as `schedule_time` if `start_delay` is not set.
+    google.protobuf.Timestamp requested_start_time = 12;
+
+    // The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
+    // up the task from matching). Not set until a worker picks up the first attempt. Not updated on
+    // subsequent retry attempts.
+    google.protobuf.Timestamp actual_start_time = 13;
 }
 
 // CallbackInfo contains the state of an attached activity callback.

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -228,15 +228,6 @@ message ActivityExecutionListInfo {
     // The difference between close time and scheduled time.
     // This field is only populated if the activity is closed.
     google.protobuf.Duration execution_duration = 11;
-
-    // The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
-    // Same as `schedule_time` if `start_delay` is not set.
-    google.protobuf.Timestamp requested_start_time = 12;
-
-    // The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
-    // up the task from matching). Not set until a worker picks up the first attempt. Not updated on
-    // subsequent retry attempts.
-    google.protobuf.Timestamp actual_start_time = 13;
 }
 
 // CallbackInfo contains the state of an attached activity callback.

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -187,14 +187,9 @@ message ActivityExecutionInfo {
     // Time to wait before making the first activity task available for dispatch. This delay is not applied to retry attempts.
     google.protobuf.Duration start_delay = 37;
 
-    // The time at which the activity is requested to start, computed as `schedule_time + start_delay`.
-    // Same as `schedule_time` if `start_delay` is not set.
-    google.protobuf.Timestamp requested_start_time = 38;
-
-    // The time at which the activity was first dispatched to a worker (i.e. when a worker first picked
-    // up the task from matching). Not set until a worker picks up the first attempt. Not updated on
-    // subsequent retry attempts.
-    google.protobuf.Timestamp actual_start_time = 39;
+    // The time at which the first activity task is made available for dispatch, computed as
+    // `schedule_time + start_delay`. Same as `schedule_time` if `start_delay` is not set.
+    google.protobuf.Timestamp execution_time = 38;
 }
 
 // Limited activity information returned in the list response.


### PR DESCRIPTION
**What changed?**
 Added execution_time to ActivityExecutionInfo (returned by DescribeActivityExecution — the time the activity is requested to start, computed as schedule_time + start_delay. Reflects the latest start_delay value if it was updated via UpdateActivityOptions. 

**Why?**
Exposing execution_time makes the desired fire time directly observable in Describe.
