### PR TITLE
Add one-time move to the versioning override API!

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11105,7 +11105,7 @@
           "description": "Required. Worker Deployment Version to receive the one-time Workflow Task."
         }
       },
-      "description": "Routes Workflow Tasks for this execution to `target_deployment_version`\nuntil a Workflow Task completes on that version, then clears the override.\n\nThis does not force the workflow's normal Versioning Behavior to become\nPinned. After the Workflow Task completes on `target_deployment_version`,\nthe workflow execution's normal Versioning Behavior and Deployment Version\nare taken from the worker's completion response.\n\nFor example, if the target worker reports Pinned, the execution will remain\npinned after this override is cleared. If the target worker reports\nAutoUpgrade, the execution will resume AutoUpgrade routing after this\noverride is cleared.\n\nIf no Workflow Task completes on `target_deployment_version`, this override\nremains pending."
+      "description": "Routes Workflow Tasks for this execution to `target_deployment_version`\nuntil a Workflow Task completes on that version, then clears the override.\n\nThis does not force the workflow's normal Versioning Behavior to become\nPinned. After the Workflow Task completes on `target_deployment_version`,\nthe workflow execution's normal Versioning Behavior and Deployment Version\nare taken from the worker's completion response.\n\nExample: if an execution is moved from version X to version Y, and version Z\nlater becomes current:\n- if worker Y reports Pinned, the execution stays on Y;\n- if worker Y reports AutoUpgrade, the execution routes to Z on a future\n  Workflow Task;\n- if worker Y reports Pinned and the workflow uses upgrade-on-continue-as-new,\n  the current run stays on Y and the execution can route to Z after\n  continue-as-new.\n\nIf no Workflow Task completes on `target_deployment_version`, this override\nremains pending."
     },
     "VersioningOverridePinnedOverride": {
       "type": "object",
@@ -20159,7 +20159,7 @@
         },
         "oneTime": {
           "$ref": "#/definitions/VersioningOverrideOneTimeOverride",
-          "description": "Temporarily override workflow task routing to a specific Worker Deployment Version\nuntil one Workflow Task completes there. After completion, the workflow\nexecution's Versioning Behavior and Deployment Version come from the\nworker's completion response."
+          "description": "Override Workflow Task routing to a specific Worker Deployment Version until\none Workflow Task completes there. After completion, the workflow execution's\nVersioning Behavior and Deployment Version come from the worker's completion\nresponse."
         },
         "behavior": {
           "$ref": "#/definitions/v1VersioningBehavior",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11105,7 +11105,7 @@
           "description": "Required. Worker Deployment Version to receive the one-time Workflow Task."
         }
       },
-      "description": "Routes Workflow Tasks for this execution to `target_deployment_version`\nuntil a Workflow Task completes on that version, then clears the override.\n\nThis does not force the workflow's normal Versioning Behavior to become\nPinned. After the Workflow Task completes on `target_deployment_version`,\nthe workflow execution's normal Versioning Behavior and Deployment Version\nare taken from the worker's completion response.\n\nExample: if an execution is moved from version X to version Y, and version Z\nlater becomes current:\n- if worker Y reports Pinned, the execution stays on Y;\n- if worker Y reports AutoUpgrade, the execution routes to Z on a future\n  Workflow Task;\n- if worker Y reports Pinned and the workflow uses upgrade-on-continue-as-new,\n  the current run stays on Y and the execution can route to Z after\n  continue-as-new.\n\nIf no Workflow Task completes on `target_deployment_version`, this override\nremains pending."
+      "description": "Routes Workflow Tasks for this execution to `target_deployment_version`\nuntil a Workflow Task completes on that version, then clears the override.\n\nThis does not force the workflow's normal Versioning Behavior to become\nPinned. After the Workflow Task completes on `target_deployment_version`,\nthe workflow execution's normal Versioning Behavior and Deployment Version\nare taken from the worker's completion response.\n\nExample: if an execution is one-time moved from version X to version Y, and\nversion Z later becomes current:\n- if worker Y reports Pinned, the execution stays on Y;\n- if worker Y reports AutoUpgrade, the execution routes to Z on a future\n  Workflow Task;\n- if worker Y reports Pinned and the workflow uses upgrade-on-continue-as-new,\n  the current run stays on Y and the execution can route to Z after\n  continue-as-new.\n\nIf no Workflow Task completes on `target_deployment_version`, this override\nremains pending."
     },
     "VersioningOverridePinnedOverride": {
       "type": "object",
@@ -20151,7 +20151,7 @@
       "properties": {
         "pinned": {
           "$ref": "#/definitions/VersioningOverridePinnedOverride",
-          "description": "Override the workflow to have Pinned behavior."
+          "description": "Override the workflow to have Pinned behavior. This is a sticky override:\nWorkflow Tasks continue to route according to this override until it is\nexplicitly removed."
         },
         "autoUpgrade": {
           "type": "boolean",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11097,7 +11097,7 @@
         }
       }
     },
-    "VersioningOverrideOneTimeMove": {
+    "VersioningOverrideOneTimeOverride": {
       "type": "object",
       "properties": {
         "targetDeploymentVersion": {
@@ -20158,8 +20158,8 @@
           "description": "Override the workflow to have AutoUpgrade behavior."
         },
         "oneTime": {
-          "$ref": "#/definitions/VersioningOverrideOneTimeMove",
-          "description": "Move the workflow to a specific Worker Deployment Version for one successful Workflow Task."
+          "$ref": "#/definitions/VersioningOverrideOneTimeOverride",
+          "description": "Temporarily override workflow task routing to a specific Worker Deployment Version\nuntil one Workflow Task completes there."
         },
         "behavior": {
           "$ref": "#/definitions/v1VersioningBehavior",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11097,6 +11097,16 @@
         }
       }
     },
+    "VersioningOverrideOneTimeMove": {
+      "type": "object",
+      "properties": {
+        "targetDeploymentVersion": {
+          "$ref": "#/definitions/v1WorkerDeploymentVersion",
+          "description": "Required. Worker Deployment Version to receive the one-time Workflow Task."
+        }
+      },
+      "description": "Routes this workflow execution to a specific Worker Deployment Version for one\nsuccessful Workflow Task, then clears the override.\n\nThis does not force the workflow's normal Versioning Behavior to become\nPinned. After the Workflow Task completes on `target_deployment_version`,\nthe workflow execution's normal Versioning Behavior and Deployment Version\nare taken from the worker's completion response.\n\nFor example, if the target worker reports Pinned, the execution will remain\npinned after this override is cleared. If the target worker reports\nAutoUpgrade, the execution will resume AutoUpgrade routing after this\noverride is cleared.\n\nIf no Workflow Task completes on `target_deployment_version`, this override\nremains pending."
+    },
     "VersioningOverridePinnedOverride": {
       "type": "object",
       "properties": {
@@ -20146,6 +20156,10 @@
         "autoUpgrade": {
           "type": "boolean",
           "description": "Override the workflow to have AutoUpgrade behavior."
+        },
+        "oneTime": {
+          "$ref": "#/definitions/VersioningOverrideOneTimeMove",
+          "description": "Move the workflow to a specific Worker Deployment Version for one successful Workflow Task."
         },
         "behavior": {
           "$ref": "#/definitions/v1VersioningBehavior",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -20159,7 +20159,7 @@
         },
         "oneTime": {
           "$ref": "#/definitions/VersioningOverrideOneTimeOverride",
-          "description": "Temporarily override workflow task routing to a specific Worker Deployment Version\nuntil one Workflow Task completes there."
+          "description": "Temporarily override workflow task routing to a specific Worker Deployment Version\nuntil one Workflow Task completes there. After completion, the workflow\nexecution's Versioning Behavior and Deployment Version come from the\nworker's completion response."
         },
         "behavior": {
           "$ref": "#/definitions/v1VersioningBehavior",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11105,7 +11105,7 @@
           "description": "Required. Worker Deployment Version to receive the one-time Workflow Task."
         }
       },
-      "description": "Routes this workflow execution to a specific Worker Deployment Version for one\nsuccessful Workflow Task, then clears the override.\n\nThis does not force the workflow's normal Versioning Behavior to become\nPinned. After the Workflow Task completes on `target_deployment_version`,\nthe workflow execution's normal Versioning Behavior and Deployment Version\nare taken from the worker's completion response.\n\nFor example, if the target worker reports Pinned, the execution will remain\npinned after this override is cleared. If the target worker reports\nAutoUpgrade, the execution will resume AutoUpgrade routing after this\noverride is cleared.\n\nIf no Workflow Task completes on `target_deployment_version`, this override\nremains pending."
+      "description": "Routes Workflow Tasks for this execution to `target_deployment_version`\nuntil a Workflow Task completes on that version, then clears the override.\n\nThis does not force the workflow's normal Versioning Behavior to become\nPinned. After the Workflow Task completes on `target_deployment_version`,\nthe workflow execution's normal Versioning Behavior and Deployment Version\nare taken from the worker's completion response.\n\nFor example, if the target worker reports Pinned, the execution will remain\npinned after this override is cleared. If the target worker reports\nAutoUpgrade, the execution will resume AutoUpgrade routing after this\noverride is cleared.\n\nIf no Workflow Task completes on `target_deployment_version`, this override\nremains pending."
     },
     "VersioningOverridePinnedOverride": {
       "type": "object",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18339,7 +18339,10 @@ components:
         pinned:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride_PinnedOverride'
-          description: Override the workflow to have Pinned behavior.
+          description: |-
+            Override the workflow to have Pinned behavior. This is a sticky override:
+             Workflow Tasks continue to route according to this override until it is
+             explicitly removed.
         autoUpgrade:
           type: boolean
           description: Override the workflow to have AutoUpgrade behavior.
@@ -18403,8 +18406,8 @@ components:
          the workflow execution's normal Versioning Behavior and Deployment Version
          are taken from the worker's completion response.
 
-         Example: if an execution is moved from version X to version Y, and version Z
-         later becomes current:
+         Example: if an execution is one-time moved from version X to version Y, and
+         version Z later becomes current:
          - if worker Y reports Pinned, the execution stays on Y;
          - if worker Y reports AutoUpgrade, the execution routes to Z on a future
            Workflow Task;

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18393,8 +18393,8 @@ components:
             - $ref: '#/components/schemas/WorkerDeploymentVersion'
           description: Required. Worker Deployment Version to receive the one-time Workflow Task.
       description: |-
-        Routes this workflow execution to a specific Worker Deployment Version for one
-         successful Workflow Task, then clears the override.
+        Routes Workflow Tasks for this execution to `target_deployment_version`
+         until a Workflow Task completes on that version, then clears the override.
 
          This does not force the workflow's normal Versioning Behavior to become
          Pinned. After the Workflow Task completes on `target_deployment_version`,

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18351,6 +18351,8 @@ components:
              until one Workflow Task completes there. After completion, the workflow
              execution's Versioning Behavior and Deployment Version come from the
              worker's completion response.
+             (-- api-linter: core::0142::time-field-type=disabled
+                 aip.dev/not-precedent: one_time describes one-time routing semantics, not a timestamp or duration. --)
         behavior:
           enum:
             - VERSIONING_BEHAVIOR_UNSPECIFIED

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18343,6 +18343,10 @@ components:
         autoUpgrade:
           type: boolean
           description: Override the workflow to have AutoUpgrade behavior.
+        oneTime:
+          allOf:
+            - $ref: '#/components/schemas/VersioningOverride_OneTimeMove'
+          description: Move the workflow to a specific Worker Deployment Version for one successful Workflow Task.
         behavior:
           enum:
             - VERSIONING_BEHAVIOR_UNSPECIFIED
@@ -18377,6 +18381,29 @@ components:
 
          Pinned behavior overrides are automatically inherited by child workflows, workflow retries, continue-as-new
          workflows, and cron workflows.
+    VersioningOverride_OneTimeMove:
+      type: object
+      properties:
+        targetDeploymentVersion:
+          allOf:
+            - $ref: '#/components/schemas/WorkerDeploymentVersion'
+          description: Required. Worker Deployment Version to receive the one-time Workflow Task.
+      description: |-
+        Routes this workflow execution to a specific Worker Deployment Version for one
+         successful Workflow Task, then clears the override.
+
+         This does not force the workflow's normal Versioning Behavior to become
+         Pinned. After the Workflow Task completes on `target_deployment_version`,
+         the workflow execution's normal Versioning Behavior and Deployment Version
+         are taken from the worker's completion response.
+
+         For example, if the target worker reports Pinned, the execution will remain
+         pinned after this override is cleared. If the target worker reports
+         AutoUpgrade, the execution will resume AutoUpgrade routing after this
+         override is cleared.
+
+         If no Workflow Task completes on `target_deployment_version`, this override
+         remains pending.
     VersioningOverride_PinnedOverride:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18345,8 +18345,10 @@ components:
           description: Override the workflow to have AutoUpgrade behavior.
         oneTime:
           allOf:
-            - $ref: '#/components/schemas/VersioningOverride_OneTimeMove'
-          description: Move the workflow to a specific Worker Deployment Version for one successful Workflow Task.
+            - $ref: '#/components/schemas/VersioningOverride_OneTimeOverride'
+          description: |-
+            Temporarily override workflow task routing to a specific Worker Deployment Version
+             until one Workflow Task completes there.
         behavior:
           enum:
             - VERSIONING_BEHAVIOR_UNSPECIFIED
@@ -18381,7 +18383,7 @@ components:
 
          Pinned behavior overrides are automatically inherited by child workflows, workflow retries, continue-as-new
          workflows, and cron workflows.
-    VersioningOverride_OneTimeMove:
+    VersioningOverride_OneTimeOverride:
       type: object
       properties:
         targetDeploymentVersion:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18348,7 +18348,9 @@ components:
             - $ref: '#/components/schemas/VersioningOverride_OneTimeOverride'
           description: |-
             Temporarily override workflow task routing to a specific Worker Deployment Version
-             until one Workflow Task completes there.
+             until one Workflow Task completes there. After completion, the workflow
+             execution's Versioning Behavior and Deployment Version come from the
+             worker's completion response.
         behavior:
           enum:
             - VERSIONING_BEHAVIOR_UNSPECIFIED

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -18347,10 +18347,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/VersioningOverride_OneTimeOverride'
           description: |-
-            Temporarily override workflow task routing to a specific Worker Deployment Version
-             until one Workflow Task completes there. After completion, the workflow
-             execution's Versioning Behavior and Deployment Version come from the
-             worker's completion response.
+            Override Workflow Task routing to a specific Worker Deployment Version until
+             one Workflow Task completes there. After completion, the workflow execution's
+             Versioning Behavior and Deployment Version come from the worker's completion
+             response.
              (-- api-linter: core::0142::time-field-type=disabled
                  aip.dev/not-precedent: one_time describes one-time routing semantics, not a timestamp or duration. --)
         behavior:
@@ -18403,10 +18403,14 @@ components:
          the workflow execution's normal Versioning Behavior and Deployment Version
          are taken from the worker's completion response.
 
-         For example, if the target worker reports Pinned, the execution will remain
-         pinned after this override is cleared. If the target worker reports
-         AutoUpgrade, the execution will resume AutoUpgrade routing after this
-         override is cleared.
+         Example: if an execution is moved from version X to version Y, and version Z
+         later becomes current:
+         - if worker Y reports Pinned, the execution stays on Y;
+         - if worker Y reports AutoUpgrade, the execution routes to Z on a future
+           Workflow Task;
+         - if worker Y reports Pinned and the workflow uses upgrade-on-continue-as-new,
+           the current run stays on Y and the execution can route to Z after
+           continue-as-new.
 
          If no Workflow Task completes on `target_deployment_version`, this override
          remains pending.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -619,6 +619,8 @@ message VersioningOverride {
         // until one Workflow Task completes there. After completion, the workflow
         // execution's Versioning Behavior and Deployment Version come from the
         // worker's completion response.
+        // (-- api-linter: core::0142::time-field-type=disabled
+        //     aip.dev/not-precedent: one_time describes one-time routing semantics, not a timestamp or duration. --)
         OneTimeOverride one_time = 5;
     }
 

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -615,8 +615,9 @@ message VersioningOverride {
         // Override the workflow to have AutoUpgrade behavior.
         bool auto_upgrade = 4;
 
-        // Move the workflow to a specific Worker Deployment Version for one successful Workflow Task.
-        OneTimeMove one_time = 5;
+        // Temporarily override workflow task routing to a specific Worker Deployment Version
+        // until one Workflow Task completes there.
+        OneTimeOverride one_time = 5;
     }
 
     // Required.
@@ -665,7 +666,7 @@ message VersioningOverride {
     //
     // If no Workflow Task completes on `target_deployment_version`, this override
     // remains pending.
-    message OneTimeMove {
+    message OneTimeOverride {
         // Required. Worker Deployment Version to receive the one-time Workflow Task.
         temporal.api.deployment.v1.WorkerDeploymentVersion target_deployment_version = 1;
     }

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -614,6 +614,9 @@ message VersioningOverride {
 
         // Override the workflow to have AutoUpgrade behavior.
         bool auto_upgrade = 4;
+
+        // Move the workflow to a specific Worker Deployment Version for one successful Workflow Task.
+        OneTimeMove one_time = 5;
     }
 
     // Required.
@@ -645,6 +648,26 @@ message VersioningOverride {
         // If omitted and the target workflow is not pinned, the override request
         // will be rejected with a PreconditionFailed error.
         temporal.api.deployment.v1.WorkerDeploymentVersion version = 2;
+    }
+
+    // Routes this workflow execution to a specific Worker Deployment Version for one
+    // successful Workflow Task, then clears the override.
+    //
+    // This does not force the workflow's normal Versioning Behavior to become
+    // Pinned. After the Workflow Task completes on `target_deployment_version`,
+    // the workflow execution's normal Versioning Behavior and Deployment Version
+    // are taken from the worker's completion response.
+    //
+    // For example, if the target worker reports Pinned, the execution will remain
+    // pinned after this override is cleared. If the target worker reports
+    // AutoUpgrade, the execution will resume AutoUpgrade routing after this
+    // override is cleared.
+    //
+    // If no Workflow Task completes on `target_deployment_version`, this override
+    // remains pending.
+    message OneTimeMove {
+        // Required. Worker Deployment Version to receive the one-time Workflow Task.
+        temporal.api.deployment.v1.WorkerDeploymentVersion target_deployment_version = 1;
     }
 
     enum PinnedOverrideBehavior {

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -609,7 +609,9 @@ message WorkflowExecutionOptions {
 message VersioningOverride {
     // Indicates whether to override the workflow to be AutoUpgrade or Pinned.
     oneof override {
-        // Override the workflow to have Pinned behavior.
+        // Override the workflow to have Pinned behavior. This is a sticky override:
+        // Workflow Tasks continue to route according to this override until it is
+        // explicitly removed.
         PinnedOverride pinned = 3;
 
         // Override the workflow to have AutoUpgrade behavior.
@@ -663,8 +665,8 @@ message VersioningOverride {
     // the workflow execution's normal Versioning Behavior and Deployment Version
     // are taken from the worker's completion response.
     //
-    // Example: if an execution is moved from version X to version Y, and version Z
-    // later becomes current:
+    // Example: if an execution is one-time moved from version X to version Y, and
+    // version Z later becomes current:
     // - if worker Y reports Pinned, the execution stays on Y;
     // - if worker Y reports AutoUpgrade, the execution routes to Z on a future
     //   Workflow Task;

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -615,10 +615,10 @@ message VersioningOverride {
         // Override the workflow to have AutoUpgrade behavior.
         bool auto_upgrade = 4;
 
-        // Temporarily override workflow task routing to a specific Worker Deployment Version
-        // until one Workflow Task completes there. After completion, the workflow
-        // execution's Versioning Behavior and Deployment Version come from the
-        // worker's completion response.
+        // Override Workflow Task routing to a specific Worker Deployment Version until
+        // one Workflow Task completes there. After completion, the workflow execution's
+        // Versioning Behavior and Deployment Version come from the worker's completion
+        // response.
         // (-- api-linter: core::0142::time-field-type=disabled
         //     aip.dev/not-precedent: one_time describes one-time routing semantics, not a timestamp or duration. --)
         OneTimeOverride one_time = 5;
@@ -663,10 +663,14 @@ message VersioningOverride {
     // the workflow execution's normal Versioning Behavior and Deployment Version
     // are taken from the worker's completion response.
     //
-    // For example, if the target worker reports Pinned, the execution will remain
-    // pinned after this override is cleared. If the target worker reports
-    // AutoUpgrade, the execution will resume AutoUpgrade routing after this
-    // override is cleared.
+    // Example: if an execution is moved from version X to version Y, and version Z
+    // later becomes current:
+    // - if worker Y reports Pinned, the execution stays on Y;
+    // - if worker Y reports AutoUpgrade, the execution routes to Z on a future
+    //   Workflow Task;
+    // - if worker Y reports Pinned and the workflow uses upgrade-on-continue-as-new,
+    //   the current run stays on Y and the execution can route to Z after
+    //   continue-as-new.
     //
     // If no Workflow Task completes on `target_deployment_version`, this override
     // remains pending.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -653,8 +653,8 @@ message VersioningOverride {
         temporal.api.deployment.v1.WorkerDeploymentVersion version = 2;
     }
 
-    // Routes this workflow execution to a specific Worker Deployment Version for one
-    // successful Workflow Task, then clears the override.
+    // Routes Workflow Tasks for this execution to `target_deployment_version`
+    // until a Workflow Task completes on that version, then clears the override.
     //
     // This does not force the workflow's normal Versioning Behavior to become
     // Pinned. After the Workflow Task completes on `target_deployment_version`,

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -616,7 +616,9 @@ message VersioningOverride {
         bool auto_upgrade = 4;
 
         // Temporarily override workflow task routing to a specific Worker Deployment Version
-        // until one Workflow Task completes there.
+        // until one Workflow Task completes there. After completion, the workflow
+        // execution's Versioning Behavior and Deployment Version come from the
+        // worker's completion response.
         OneTimeOverride one_time = 5;
     }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- WISOTT

<!-- Tell your future self why have you made these changes -->
**Why?**
- So that operators can have a versioning override that is not sticky. The idea is that the next task of the workflow execution moves to the target version, after which the behaviour/version of the workflow are dictated by the worker response.

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
- No, since this is a new option that I am adding whose default value is false (it's opt-in)


<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
- [here](https://github.com/temporalio/temporal/pull/10763)

