### PR TITLE
Add first_execution_run_id to StartWorkflowExecutionResponse

### DIFF
--- a/nexus/workflow-service.wit
+++ b/nexus/workflow-service.wit
@@ -104,6 +104,7 @@ interface workflow-service {
     started: option<bool>,
     /// @nexus.omit
     signal-link: placeholder,
+    first-execution-run-id: string,
   }
 
   /// @nexus.doc

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -19206,6 +19206,10 @@
           "type": "string",
           "description": "The run id of the workflow that was started - or just signaled, if it was already running."
         },
+        "firstExecutionRunId": {
+          "type": "string",
+          "description": "If the workflow was started as a result of a de-dupe, this field will contain the run id of the first execution in the chain."
+        },
         "started": {
           "type": "boolean",
           "description": "If true, a new workflow was started."
@@ -19393,6 +19397,10 @@
         "runId": {
           "type": "string",
           "description": "The run id of the workflow that was started - or used (via WorkflowIdConflictPolicy USE_EXISTING)."
+        },
+        "firstExecutionRunId": {
+          "type": "string",
+          "description": "If the workflow was started as a result of a de-dupe, this field will contain the run id of the first execution in the chain."
         },
         "started": {
           "type": "boolean",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -16462,6 +16462,9 @@ components:
         runId:
           type: string
           description: The run id of the workflow that was started - or just signaled, if it was already running.
+        firstExecutionRunId:
+          type: string
+          description: If the workflow was started as a result of a de-dupe, this field will contain the run id of the first execution in the chain.
         started:
           type: boolean
           description: If true, a new workflow was started.
@@ -17088,6 +17091,9 @@ components:
         runId:
           type: string
           description: The run id of the workflow that was started - or used (via WorkflowIdConflictPolicy USE_EXISTING).
+        firstExecutionRunId:
+          type: string
+          description: If the workflow was started as a result of a de-dupe, this field will contain the run id of the first execution in the chain.
         started:
           type: boolean
           description: If true, a new workflow was started.

--- a/temporal/api/errordetails/v1/message.proto
+++ b/temporal/api/errordetails/v1/message.proto
@@ -27,6 +27,7 @@ message NotFoundFailure {
 message WorkflowExecutionAlreadyStartedFailure {
     string start_request_id = 1;
     string run_id = 2;
+    string first_execution_run_id = 3;
 }
 
 message NamespaceNotActiveFailure {

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -222,6 +222,8 @@ message StartWorkflowExecutionRequest {
 message StartWorkflowExecutionResponse {
     // The run id of the workflow that was started - or used (via WorkflowIdConflictPolicy USE_EXISTING).
     string run_id = 1;
+    // If the workflow was started as a result of a de-dupe, this field will contain the run id of the first execution in the chain.
+    string first_execution_run_id = 6;
     // If true, a new workflow was started.
     bool started = 3;
     // Current execution status of the workflow. Typically remains WORKFLOW_EXECUTION_STATUS_RUNNING
@@ -939,6 +941,8 @@ message SignalWithStartWorkflowExecutionRequest {
 message SignalWithStartWorkflowExecutionResponse {
     // The run id of the workflow that was started - or just signaled, if it was already running.
     string run_id = 1;
+    // If the workflow was started as a result of a de-dupe, this field will contain the run id of the first execution in the chain.
+    string first_execution_run_id = 4;
     // If true, a new workflow was started.
     bool started = 2;
     // Link to be associated with the WorkflowExecutionSignaled event.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add FirstExecutionRunID to start response


<!-- Tell your future self why have you made these changes -->
**Why?**

closes https://github.com/temporalio/temporal/issues/8537

>Today, when SDK gets StartWorkflowExecutionResponse with started as false or WorkflowExecutionAlreadyStartedFailure, it doesn't include the first execution run ID that we can bind successive calls to. It only provides the run ID. If you start a workflow today successfully, SDK uses the run ID as the first execution run ID on successive calls like cancel and signal and such. But if you start a workflow today w/ conflict policy of use existing and it doesn't start, that run ID is not acceptable for first execution run ID.

<!-- Are there any breaking changes on binary or code level? -->

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/10873
