### PR TITLE
Update system Nexus WIT generator annotations

### DIFF
--- a/nexus/deps/nexus-temporal-types/model.wit
+++ b/nexus/deps/nexus-temporal-types/model.wit
@@ -4,22 +4,29 @@ interface model {
   /// String-shaped placeholder for semantic types that generators reinterpret.
   type placeholder = string;
 
-  /// @nexus.proto "temporal.api.common.v1.Payload" typescript-package="@temporalio/proto"
-  /// @nexus.type python="typing.Any" typescript="common.Payload" typescript-package="@temporalio/common"
+  /// @nexus.proto "temporal.api.common.v1.Payload" typescript-import="@temporalio/proto"
+  /// @nexus.type
+  ///   python="typing.Any"
+  ///   typescript="common.Payload"
+  ///   dotnet="object?"
+  ///   dotnet-to="ProtoExtensions.ToPayload"
+  ///   typescript-import="@temporalio/common"
   type payload = placeholder;
 
   /// @nexus.proto "temporal.api.common.v1.Payloads"
-  ///   typescript-package="@temporalio/proto"
+  ///   typescript-import="@temporalio/proto"
+  /// @nexus.type dotnet="IReadOnlyCollection<object?>" dotnet-to="ProtoExtensions.ToPayloads"
   type payloads = list<payload>;
 
   /// Callable result annotation for workflow functions.
   /// @nexus.type
   ///   python="collections.abc.Awaitable[WorkflowResult]"
   ///   typescript="Promise<any>"
+  ///   dotnet="System.Threading.Tasks.Task<object?>"
   type workflow-result = placeholder;
 
   /// Receiver/context argument for workflow callable method forms.
-  /// @nexus.type python="typing.Any" typescript="any"
+  /// @nexus.type python="typing.Any" typescript="any" dotnet="object"
   type callable-prefix = placeholder;
 
   /// @nexus.function-args
@@ -29,7 +36,7 @@ interface model {
   workflow-call: async func(callable-prefix: callable-prefix, args: payloads) -> workflow-result;
 
   /// Callable result annotation for signal functions.
-  /// @nexus.type python="None | collections.abc.Awaitable[None]" typescript="void"
+  /// @nexus.type python="None | collections.abc.Awaitable[None]" typescript="void" dotnet="void"
   type signal-result = placeholder;
 
   /// @nexus.function-args
@@ -38,8 +45,12 @@ interface model {
   ///   typescript-drop-prefix=true
   signal-call: func(callable-prefix: callable-prefix, signal-args: payloads) -> signal-result;
 
-  /// @nexus.proto "temporal.api.common.v1.WorkflowType" typescript-package="@temporalio/proto"
-  /// @nexus.type python="str" typescript="string"
+  /// @nexus.proto "temporal.api.common.v1.WorkflowType" typescript-import="@temporalio/proto"
+  /// @nexus.type
+  ///   python="str"
+  ///   typescript="string"
+  ///   dotnet="string"
+  ///   dotnet-to="ProtoExtensions.ToWorkflowTypeProto"
   type workflow-type = placeholder;
 
   /// @nexus.function
@@ -48,6 +59,8 @@ interface model {
   ///   args-field="input"
   ///   result-type-parameter="WorkflowResult"
   ///   alternate-type="workflow-type"
+  ///   dotnet-name-extractor="TemporalFunctionNames.WorkflowName"
+  ///   dotnet-call-extractor="TemporalFunctionNames.ExtractCall"
   /// @nexus.add-rpc-compatible-with "workflow-type"
   type workflow-function = placeholder;
 
@@ -56,66 +69,73 @@ interface model {
   ///   args-field="signal-input"
   ///   alternate-type="string"
   ///   python-converter="signal_function_to_proto"
-  ///   typescript-converter="signalFunctionToProto"
+  ///   typescript-name-extractor="signalFunctionName"
+  ///   dotnet-name-extractor="TemporalFunctionNames.SignalName"
+  ///   dotnet-call-extractor="TemporalFunctionNames.ExtractCall"
+  ///   typescript-value-type="workflow.SignalDefinition<any[]>"
+  ///   typescript-args-type="Value extends workflow.SignalDefinition<infer Args, any> ? Args : never"
+  ///   typescript-import="@temporalio/workflow"
   /// @nexus.add-rpc-compatible-with "string"
-  /// @nexus.typescript-with-arguments
-  ///   signature="signal-call"
-  ///   args-field="signal-input"
-  ///   alternate-type="string"
-  ///   value-type="workflow.SignalDefinition<any[]>"
-  ///   args-type="Value extends workflow.SignalDefinition<infer Args, any> ? Args : never"
-  ///   name-expr="value.name"
-  ///   typescript-package="@temporalio/workflow"
   type signal-function = placeholder;
 
-  /// @nexus.proto "temporal.api.common.v1.RetryPolicy" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.common.v1.RetryPolicy" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="temporalio.common.RetryPolicy"
   ///   typescript="common.RetryPolicy"
-  ///   typescript-package="@temporalio/common"
+  ///   dotnet="Temporalio.Common.RetryPolicy"
+  ///   typescript-import="@temporalio/common"
   type retry-policy = placeholder;
 
-  /// @nexus.proto "temporal.api.taskqueue.v1.TaskQueue" typescript-package="@temporalio/proto"
-  /// @nexus.type python="str" typescript="string"
+  /// @nexus.proto "temporal.api.taskqueue.v1.TaskQueue" typescript-import="@temporalio/proto"
+  /// @nexus.type
+  ///   python="str"
+  ///   typescript="string"
+  ///   dotnet="string"
+  ///   dotnet-to="ProtoExtensions.ToTaskQueueProto"
   type task-queue = placeholder;
 
-  /// @nexus.proto "temporal.api.common.v1.Memo" typescript-package="@temporalio/proto"
-  /// @nexus.type python="collections.abc.Mapping[str, typing.Any]" typescript="Record<string, unknown>"
+  /// @nexus.proto "temporal.api.common.v1.Memo" typescript-import="@temporalio/proto"
+  /// @nexus.type python="collections.abc.Mapping[str, typing.Any]" typescript="Record<string, unknown>" dotnet="IReadOnlyDictionary<string, object?>"
   type memo = placeholder;
 
-  /// @nexus.proto "temporal.api.common.v1.SearchAttributes" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.common.v1.SearchAttributes" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="temporalio.common.TypedSearchAttributes"
   ///   typescript="common.TypedSearchAttributes"
-  ///   typescript-package="@temporalio/common"
+  ///   dotnet="Temporalio.Common.SearchAttributeCollection"
+  ///   typescript-import="@temporalio/common"
   type search-attributes = placeholder;
 
-  /// @nexus.proto "temporal.api.common.v1.Priority" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.common.v1.Priority" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="temporalio.common.Priority"
   ///   typescript="common.Priority"
-  ///   typescript-package="@temporalio/common"
+  ///   dotnet="Temporalio.Common.Priority"
+  ///   typescript-import="@temporalio/common"
   type priority = placeholder;
 
-  /// @nexus.proto "temporal.api.workflow.v1.VersioningOverride" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.workflow.v1.VersioningOverride" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="temporalio.common.VersioningOverride"
   ///   typescript="common.VersioningOverride"
-  ///   typescript-package="@temporalio/common"
+  ///   dotnet="Temporalio.Common.VersioningOverride"
+  ///   typescript-import="@temporalio/common"
   type versioning-override = placeholder;
 
-  /// @nexus.proto "google.protobuf.Duration" typescript-package="@temporalio/proto"
+  /// @nexus.proto "google.protobuf.Duration" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="datetime.timedelta"
   ///   typescript="common.Duration"
-  ///   typescript-package="@temporalio/common"
+  ///   dotnet="System.TimeSpan"
+  ///   typescript-import="@temporalio/common"
   type duration = placeholder;
 
-  /// @nexus.proto "temporal.api.enums.v1.WorkflowIdReusePolicy" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.enums.v1.WorkflowIdReusePolicy" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="temporalio.common.WorkflowIDReusePolicy"
   ///   typescript="common.WorkflowIdReusePolicy"
-  ///   typescript-package="@temporalio/common"
+  ///   dotnet="Temporalio.Api.Enums.V1.WorkflowIdReusePolicy"
+  ///   typescript-import="@temporalio/common"
   enum workflow-id-reuse-policy {
     allow-duplicate,
     allow-duplicate-failed-only,
@@ -123,27 +143,28 @@ interface model {
     terminate-if-running,
   }
 
-  /// @nexus.proto "temporal.api.enums.v1.WorkflowIdConflictPolicy" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.enums.v1.WorkflowIdConflictPolicy" typescript-import="@temporalio/proto"
   /// @nexus.type
   ///   python="temporalio.common.WorkflowIDConflictPolicy"
   ///   typescript="common.WorkflowIdConflictPolicy"
-  ///   typescript-package="@temporalio/common"
+  ///   dotnet="Temporalio.Api.Enums.V1.WorkflowIdConflictPolicy"
+  ///   typescript-import="@temporalio/common"
   enum workflow-id-conflict-policy {
     fail,
     use-existing,
     terminate-existing,
   }
 
-  /// @nexus.proto "temporal.api.sdk.v1.UserMetadata" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.sdk.v1.UserMetadata" typescript-import="@temporalio/proto"
   /// @nexus.flatten-in-api
   record user-metadata {
     /// @nexus.doc "Single-line fixed summary for the workflow execution that may appear in UI and CLI. This can be in single-line Temporal Markdown format."
     /// @nexus.proto-field "summary"
-    /// @nexus.flattened-type python="str" typescript="string"
+    /// @nexus.flattened-type python="str" typescript="string" dotnet="string"
     static-summary: option<payload>,
     /// @nexus.doc "General fixed details for the workflow execution that may appear in UI and CLI. This can be in Temporal Markdown format and can span multiple lines. This value is fixed on the workflow execution and cannot be updated."
     /// @nexus.proto-field "details"
-    /// @nexus.flattened-type python="str" typescript="string"
+    /// @nexus.flattened-type python="str" typescript="string" dotnet="string"
     static-details: option<payload>,
   }
 }

--- a/nexus/workflow-service.wit
+++ b/nexus/workflow-service.wit
@@ -6,6 +6,8 @@ world system {
 
 /// @nexus.endpoint "__temporal_system"
 /// @nexus.service-name "temporal.api.workflowservice.v1.WorkflowService"
+/// @nexus.namespace dotnet="Temporalio.Workflows"
+/// @nexus.operations-class dotnet="Workflow"
 /// @nexus.delay-load-temporalio-workflow
 /// @nexus.experimental
 interface workflow-service {
@@ -28,11 +30,12 @@ interface workflow-service {
 
   /// @nexus.doc "Request fields for signaling a workflow, starting it first if needed."
   /// @nexus.experimental
-  /// @nexus.proto "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest" typescript-import="@temporalio/proto"
   record signal-with-start-workflow-request {
     /// @nexus.doc
     ///   python="Workflow type name or callable identifying the workflow to start."
     ///   typescript="Workflow type name or workflow function identifying the workflow to start."
+    ///   dotnet="Workflow type name or workflow expression identifying the workflow to start."
     /// @nexus.proto-field "workflow_type"
     workflow: workflow-function,
     /// @nexus.doc "Unique identifier for the workflow execution."
@@ -43,6 +46,7 @@ interface workflow-service {
     /// @nexus.doc
     ///   python="Signal name or callable to send with the start request."
     ///   typescript="Signal name or signal definition to send with the start request."
+    ///   dotnet="Signal name or signal expression to send with the start request."
     /// @nexus.proto-field "signal_name"
     signal: signal-function,
     /// @nexus.doc "Total workflow execution timeout, including retries and continue-as-new."
@@ -81,7 +85,7 @@ interface workflow-service {
     /// @nexus.proto-field "workflow_start_delay"
     start-delay: option<duration>,
     user-metadata: option<user-metadata>,
-    /// @nexus.source python="workflow_namespace" typescript="workflowNamespace"
+    /// @nexus.source python="workflow_namespace" typescript="workflowNamespace" dotnet="TemporalWorkflowContext.WorkflowNamespace"
     namespace: string,
     /// @nexus.omit
     control: placeholder,
@@ -94,7 +98,7 @@ interface workflow-service {
   }
 
   /// @nexus.experimental
-  /// @nexus.proto "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse" typescript-package="@temporalio/proto"
+  /// @nexus.proto "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse" typescript-import="@temporalio/proto"
   record signal-with-start-workflow-response {
     run-id: option<string>,
     started: option<bool>,
@@ -110,7 +114,9 @@ interface workflow-service {
   ///   python="temporalio.workflow.get_external_workflow_handle(request.id, run_id=result.run_id)"
   ///   typescript-type="workflow.ExternalWorkflowHandle"
   ///   typescript="workflow.getExternalWorkflowHandle(request.id, result.runId ?? undefined)"
-  ///   typescript-package="@temporalio/workflow"
+  ///   typescript-import="@temporalio/workflow"
+  ///   dotnet-type="Temporalio.Workflows.ExternalWorkflowHandle"
+  ///   dotnet="Temporalio.Workflows.Workflow.GetExternalWorkflowHandle(request.Id, result.RunId)"
   /// @nexus.operation name="SignalWithStartWorkflowExecution"
   /// @nexus.experimental
   signal-with-start-workflow: func(


### PR DESCRIPTION
## Summary
- add DotNet generator annotations for the system Nexus workflow service WIT
- update TypeScript WIT directives from package-based imports to import directives
- add DotNet type/source/transform metadata to shared Nexus Temporal model types

## Testing
- git diff --check