### PR TITLE
remove reset_heartbeats field in ResetActivityExecutionRequest

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -13,6 +13,18 @@ breaking:
     - WIRE_JSON
   ignore:
     - google
+  ignore_only:
+    # TODO(seankane): Remove these temporary breaking-change ignores after this PR merges.
+    FIELD_SAME_JSON_NAME:
+      - temporal/api/workflowservice/v1/request_response.proto
+    FIELD_SAME_NAME:
+      - temporal/api/workflowservice/v1/request_response.proto
+    FIELD_WIRE_JSON_COMPATIBLE_TYPE:
+      - temporal/api/workflowservice/v1/request_response.proto
+    FIELD_NO_DELETE_UNLESS_NAME_RESERVED:
+      - temporal/api/workflowservice/v1/request_response.proto
+    FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED:
+      - temporal/api/workflowservice/v1/request_response.proto
 lint:
   use:
     - DEFAULT

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11533,10 +11533,6 @@
           "type": "string",
           "description": "The identity of the client who initiated this request."
         },
-        "resetHeartbeat": {
-          "type": "boolean",
-          "description": "Indicates that activity should reset heartbeat details.\nThis flag will be applied only to the new instance of the activity."
-        },
         "keepPaused": {
           "type": "boolean",
           "title": "If activity is paused, it will remain paused after reset"

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -14789,11 +14789,6 @@ components:
         identity:
           type: string
           description: The identity of the client who initiated this request.
-        resetHeartbeat:
-          type: boolean
-          description: |-
-            Indicates that activity should reset heartbeat details.
-             This flag will be applied only to the new instance of the activity.
         keepPaused:
           type: boolean
           description: If activity is paused, it will remain paused after reset

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2328,24 +2328,20 @@ message ResetActivityExecutionRequest {
     // The identity of the client who initiated this request.
     string identity = 5;
 
-    // Indicates that activity should reset heartbeat details.
-    // This flag will be applied only to the new instance of the activity.
-    bool reset_heartbeat = 6;
-
     // If activity is paused, it will remain paused after reset
-    bool keep_paused = 7;
+    bool keep_paused = 6;
 
     // If set, and activity is in backoff, the activity will start at a random time within the specified jitter duration.
     // (unless it is paused and keep_paused is set)
-    google.protobuf.Duration jitter = 8;
+    google.protobuf.Duration jitter = 7;
 
     // If set, the activity options will be restored to the defaults.
     // Default options are then options activity was created with.
     // They are part of the first schedule event.
-    bool restore_original_options = 9;
+    bool restore_original_options = 8;
 
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
-    string resource_id = 10;
+    string resource_id = 9;
 }
 
 // Deprecated. Use `ResetActivityExecutionRequest`.


### PR DESCRIPTION
**What changed?**
Remove the `reset_heartbeat` field from `temporal.api.workflowservice.v1.ResetActivityExecutionRequest`.

**Why?**
The new default behavior will be to reset heartbeats with a reset request so this field is no longer needed.

**Breaking changes**
This is _technically_ a breaking change, but this endpoint has not been published in the server yet so no users can actually use this field.

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
N/A