### PR TITLE
Add SUGGEST_CONTINUE_AS_NEW_REASON_TOO_MANY_SIGNALS enum value

### DIFF
--- a/temporal/api/enums/v1/workflow.proto
+++ b/temporal/api/enums/v1/workflow.proto
@@ -222,4 +222,7 @@ enum SuggestContinueAsNewReason {
     // See target_worker_deployment_version_changed to find out if Target Version Changed.
     reserved 4;
     reserved "SUGGEST_CONTINUE_AS_NEW_REASON_TARGET_WORKER_DEPLOYMENT_VERSION_CHANGED";
+
+    // Workflow's signal count is approaching the configured maximum signals per execution.
+    SUGGEST_CONTINUE_AS_NEW_REASON_TOO_MANY_SIGNALS = 5;
 }


### PR DESCRIPTION
## What changed?

Adds a new value to the `SuggestContinueAsNewReason` enum:

```proto
SUGGEST_CONTINUE_AS_NEW_REASON_TOO_MANY_SIGNALS = 5;
```

placed after the existing `reserved 4` block, following the file's enum-ordering style.

## Why?

Resolves the API/proto portion of temporalio/temporal#10941.

Today the server has a **hard** limit on signals (`maximumSignalsPerExecution`, default 10000) that rejects new signals outright via `ErrSignalsLimitExceeded`, but no **soft** `suggest-continue-as-new` pathway that warns the worker *before* the hard limit bites — unlike history size, history event count, and updates, which all already have a corresponding `SuggestContinueAsNewReason`.

This PR adds only the enum value. The server-side companion PR wires it into the suggest computation (a new namespace-scoped threshold config key), the metric tag, and the persisted/SDK-visible reasons field. This mirrors how `TOO_MANY_UPDATES` came to exist upstream before the server consumed it.

## Breaking changes

None. Appending a new enum value to a proto3 `enum` is wire-compatible (the persisted `WorkflowTaskSuggestContinueAsNewReasons` is a repeated `int32`; older readers round-trip the unknown int, regenerated SDKs see the named constant). No existing value changes.

## Server PR

temporalio/temporal#10941 (companion server PR to follow this merge): adds the `history.maximumSignalsPerExecution.suggestContinueAsNewThreshold` dynamic-config key, the inline suggest computation in `workflow_task_state_machine.go`, the `SuggestContinueAsNewReasonTooManySignals` metric tag, and tests. The feature defaults to disabled (threshold `0`), so it is a strict no-op for any deployment that does not opt in.