### PR TITLE
Add scale_decisions to WorkerPollerInfo

### DIFF
--- a/temporal/api/worker/v1/message.proto
+++ b/temporal/api/worker/v1/message.proto
@@ -22,6 +22,11 @@ message WorkerPollerInfo {
 
   // Set true if the number of concurrent pollers is auto-scaled
   bool is_autoscaling = 3;
+
+  // Counts of poller autoscaler scale decisions since the last heartbeat, keyed by
+  // reason (e.g. "server_up", "server_up_suppressed", "empty_poll_down", "re_halve").
+  // Only set when the poller count is auto-scaled.
+  map<string, int64> scale_decisions = 4;
 }
 
 message WorkerSlotsInfo {


### PR DESCRIPTION
## What changed

Adds a `map<string, int64> scale_decisions` field (tag 4) to `WorkerPollerInfo`.

It carries a per-poller-type breakdown of poller autoscaler scale decisions **since the last heartbeat**, keyed by reason:
`server_up`, `server_up_suppressed`, `server_down`, `empty_poll_down`, `re_halve`, `error_down`. Only set when the poller count is auto-scaled.

## Why

Poller autoscaling decisions (including when a server-requested scale-up is *suppressed* because the worker's throughput gate is closed) are currently only visible via SDK metrics. Surfacing them in the worker heartbeat makes scaling behavior observable server-side without a metrics pipeline.

## Consumer

Go SDK: temporalio/sdk-go (companion PR wires up the SDK to populate this field per interval).