### PR TITLE
Add execution_time to ActivityExecutionListInfo

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13555,6 +13555,11 @@
         "executionDuration": {
           "type": "string",
           "description": "The difference between close time and scheduled time.\nThis field is only populated if the activity is closed."
+        },
+        "executionTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the first activity task is made available for dispatch, computed as\n`schedule_time + start_delay`. Same as `schedule_time` if `start_delay` is not set."
         }
       },
       "description": "Limited activity information returned in the list response.\nWhen adding fields here, ensure that it is also present in ActivityExecutionInfo (note that it\nmay already be present in ActivityExecutionInfo but not at the top-level)."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9913,6 +9913,12 @@ components:
           description: |-
             The difference between close time and scheduled time.
              This field is only populated if the activity is closed.
+        executionTime:
+          type: string
+          description: |-
+            The time at which the first activity task is made available for dispatch, computed as
+             `schedule_time + start_delay`. Same as `schedule_time` if `start_delay` is not set.
+          format: date-time
       description: |-
         Limited activity information returned in the list response.
          When adding fields here, ensure that it is also present in ActivityExecutionInfo (note that it

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -223,6 +223,9 @@ message ActivityExecutionListInfo {
     // The difference between close time and scheduled time.
     // This field is only populated if the activity is closed.
     google.protobuf.Duration execution_duration = 11;
+    // The time at which the first activity task is made available for dispatch, computed as
+    // `schedule_time + start_delay`. Same as `schedule_time` if `start_delay` is not set.
+    google.protobuf.Timestamp execution_time = 12;
 }
 
 // CallbackInfo contains the state of an attached activity callback.


### PR DESCRIPTION
**What changed?**
Add execution_time (field 12) to ActivityExecutionListInfo, mirroring the existing field on ActivityExecutionInfo. 

**Why?**
So list responses expose the effective dispatch time (schedule_time + start_delay) without fetching full execution info.
