### PR TITLE
Add RESOURCE_EXHAUSTED_CAUSE_CALLER_RPS_LIMIT resource-exhausted cause

### DIFF
--- a/temporal/api/enums/v1/failed_cause.proto
+++ b/temporal/api/enums/v1/failed_cause.proto
@@ -127,6 +127,8 @@ enum ResourceExhaustedCause {
     RESOURCE_EXHAUSTED_CAUSE_OPS_LIMIT = 9;
     // Limits related to Worker Deployments are reached.
     RESOURCE_EXHAUSTED_CAUSE_WORKER_DEPLOYMENT_LIMITS = 10;
+    // Caller exceeds Nexus requests per second limit.
+    RESOURCE_EXHAUSTED_CAUSE_CALLER_RPS_LIMIT = 11;
 }
 
 enum ResourceExhaustedScope {


### PR DESCRIPTION
**What changed?**
Adds `RESOURCE_EXHAUSTED_CAUSE_CALLER_RPS_LIMIT = 11` to the `ResourceExhaustedCause` enum.

**Why?**
Surfaces per-caller (Nexus) rate limiting as a distinct resource-exhausted cause.

**Breaking changes**
None
