### PR TITLE
Make standalone_nexus_operation capability optional for field presence

### DIFF
--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -53,7 +53,7 @@ message NamespaceInfo {
         // True if the namespace supports worker commands (server-to-worker communication via control queues).
         bool worker_commands = 10;
         // True if the namespace supports standalone Nexus operations.
-        bool standalone_nexus_operation = 11;
+        optional bool standalone_nexus_operation = 11;
         // True if the namespace supports attaching callbacks on workflow updates
         bool workflow_update_callbacks = 12;
         // When true, workers should use poller autoscaling by default unless explicitly configured otherwise.


### PR DESCRIPTION
## What

Change `NamespaceInfo.Capabilities.standalone_nexus_operation` from an implicit-presence `bool` to `optional bool`.

## Why

With a plain proto3 `bool`, a `false` value is indistinguishable from an unset field on the wire (both are omitted). This means a `DescribeNamespace` client cannot tell apart:

1. **field absent** — server too old to know the capability → not supported
2. **field present, `false`** — server supports it, but the dynamic config is disabled
3. **field present, `true`** — supported and enabled

Cases 1 and 2 currently collapse into "field omitted". Marking the field `optional` adds explicit field presence, so a server that knows the capability always emits it (`true` or `false`), and only an older server omits it — giving the UI a reliable three-state signal.

## Compatibility

- **Wire format:** compatible — `optional bool` encodes identically to `bool` on the same field number.
- **Generated Go:** source-breaking — the field regenerates as `*bool` (with a `Has...()` accessor). Downstream (temporal server) `Capabilities{...}` literal must wrap the value in `proto.Bool(...)`; getter reads are unaffected.
- **buf breaking check:** this changes field cardinality (implicit → explicit presence) and will likely trip the breaking-change detector, needing a waiver.

Draft pending discussion on whether to apply the same treatment to the other capability bools.