### PR TITLE
Bump buf to v1.71.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ api-linter-install:
 
 buf-install:
 	printf $(COLOR) "Install/update buf..."
-	go install github.com/bufbuild/buf/cmd/buf@v1.27.0
+	go install github.com/bufbuild/buf/cmd/buf@v1.71.0
 
 ##### Sync external proto dependencies #####
 sync-nexus-annotations:


### PR DESCRIPTION
## What

Bump the pinned buf CLI from `v1.27.0` → `v1.71.0` (`Makefile` `buf-install`).

## Why

Prerequisite for a follow-up PR that adds a custom buf **check plugin** to enforce that newly added `bool` capability fields use `optional` (explicit field presence). Custom check plugins require buf ≥ 1.32 and `buf.yaml` v2 `plugins`.

Splitting the bump out so it can land and bake independently of the linter change.

## Validation

With buf 1.71.0 against the current (unchanged) v1 config:
- `buf lint` → passes (one non-fatal deprecation notice: the `DEFAULT` lint category is now `STANDARD`; cleaned up in the v2 migration that ships with the linter PR).
- `buf breaking --against ...#branch=main` → passes.

No config changes in this PR — the v2 migration and `plugins` wiring come with the linter.