### PR TITLE
Add standalone activity start delay to namespace capabilities

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16908,6 +16908,10 @@
         "standaloneActivityStartDelay": {
           "type": "boolean",
           "description": "True if the namespace supports start delay for standalone activities."
+        },
+        "standaloneActivityStartBatchOperations": {
+          "type": "boolean",
+          "description": "True if the namespace supports batch operations for standalone activities."
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16904,6 +16904,10 @@
         "workflowTaskCompletionPagination": {
           "type": "boolean",
           "description": "True if the namespace supports pagination of `RespondWorkflowTaskCompleted` request."
+        },
+        "standaloneActivityStartDelay": {
+          "type": "boolean",
+          "description": "True if the namespace supports start delay for standalone activities."
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16909,7 +16909,7 @@
           "type": "boolean",
           "description": "True if the namespace supports start delay for standalone activities."
         },
-        "standaloneActivityStartBatchOperations": {
+        "standaloneActivityBatchOperations": {
           "type": "boolean",
           "description": "True if the namespace supports batch operations for standalone activities."
         }

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13296,6 +13296,9 @@ components:
         workflowTaskCompletionPagination:
           type: boolean
           description: True if the namespace supports pagination of `RespondWorkflowTaskCompleted` request.
+        standaloneActivityStartDelay:
+          type: boolean
+          description: True if the namespace supports start delay for standalone activities.
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13299,6 +13299,9 @@ components:
         standaloneActivityStartDelay:
           type: boolean
           description: True if the namespace supports start delay for standalone activities.
+        standaloneActivityStartBatchOperations:
+          type: boolean
+          description: True if the namespace supports batch operations for standalone activities.
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13299,7 +13299,7 @@ components:
         standaloneActivityStartDelay:
           type: boolean
           description: True if the namespace supports start delay for standalone activities.
-        standaloneActivityStartBatchOperations:
+        standaloneActivityBatchOperations:
           type: boolean
           description: True if the namespace supports batch operations for standalone activities.
       description: Namespace capability details. Should contain what features are enabled in a namespace.

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -60,6 +60,8 @@ message NamespaceInfo {
         bool poller_autoscaling_auto_enroll = 13;
         // True if the namespace supports pagination of `RespondWorkflowTaskCompleted` request.
         bool workflow_task_completion_pagination = 14;
+        // True if the namespace supports start delay for standalone activities.
+        bool standalone_activity_start_delay = 15;
     }
 
     // Namespace configured limits

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -62,6 +62,8 @@ message NamespaceInfo {
         bool workflow_task_completion_pagination = 14;
         // True if the namespace supports start delay for standalone activities.
         bool standalone_activity_start_delay = 15;
+        // True if the namespace supports batch operations for standalone activities.
+        bool standalone_activity_start_batch_operations = 16;
     }
 
     // Namespace configured limits

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -63,7 +63,7 @@ message NamespaceInfo {
         // True if the namespace supports start delay for standalone activities.
         bool standalone_activity_start_delay = 15;
         // True if the namespace supports batch operations for standalone activities.
-        bool standalone_activity_start_batch_operations = 16;
+        bool standalone_activity_batch_operations = 16;
     }
 
     // Namespace configured limits


### PR DESCRIPTION
**What changed?**
Added the standalone_activity_start_delay field to NamespaceInfo.Capabilities.

**Why?**
Clients need to determine whether standalone activity start delay is effectively available for a namespace without relying on server-version checks. This lets UI clients hide start-delay controls when the feature is disabled by server configuration.
