### PR TITLE
Add namespace capability for SAA operator commands

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -16913,6 +16913,10 @@
         "standaloneActivityBatchOperations": {
           "type": "boolean",
           "description": "True if the namespace supports batch operations for standalone activities."
+        },
+        "standaloneActivityOperatorCommands": {
+          "type": "boolean",
+          "description": "True if the namespace supports standalone activity operator commands."
         }
       },
       "description": "Namespace capability details. Should contain what features are enabled in a namespace."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -13304,6 +13304,9 @@ components:
         standaloneActivityBatchOperations:
           type: boolean
           description: True if the namespace supports batch operations for standalone activities.
+        standaloneActivityOperatorCommands:
+          type: boolean
+          description: True if the namespace supports standalone activity operator commands.
       description: Namespace capability details. Should contain what features are enabled in a namespace.
     NamespaceInfo_Limits:
       type: object

--- a/temporal/api/namespace/v1/message.proto
+++ b/temporal/api/namespace/v1/message.proto
@@ -64,6 +64,8 @@ message NamespaceInfo {
         bool standalone_activity_start_delay = 15;
         // True if the namespace supports batch operations for standalone activities.
         bool standalone_activity_batch_operations = 16;
+        // True if the namespace supports standalone activity operator commands.
+        bool standalone_activity_operator_commands = 17;
     }
 
     // Namespace configured limits


### PR DESCRIPTION
**What changed?**
Add namespace capability field for SAA operator commands

**Why?**
Allows the UI and server to rollout independently.

**Breaking changes**
NA

**Server PR**
NA