### PR TITLE
Fix standalone activity expiration_time doc to match actual behavior

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13429,7 +13429,7 @@
         "expirationTime": {
           "type": "string",
           "format": "date-time",
-          "description": "Scheduled time + schedule to close timeout."
+          "description": "The time at which the activity's Schedule-to-Close timeout expires.\nCalculated as `schedule_time` + `start_delay` + `schedule_to_close_timeout`."
         },
         "closeTime": {
           "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9770,7 +9770,9 @@ components:
           format: date-time
         expirationTime:
           type: string
-          description: Scheduled time + schedule to close timeout.
+          description: |-
+            The time at which the activity's Schedule-to-Close timeout expires.
+             Calculated as `schedule_time` + `start_delay` + `schedule_to_close_timeout`.
           format: date-time
         closeTime:
           type: string

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -124,7 +124,8 @@ message ActivityExecutionInfo {
     google.protobuf.Duration execution_duration = 16;
     // Time the activity was originally scheduled via a StartActivityExecution request.
     google.protobuf.Timestamp schedule_time = 17;
-    // Scheduled time + schedule to close timeout.
+    // The time at which the activity's Schedule-to-Close timeout expires.
+    // Calculated as `schedule_time` + `start_delay` + `schedule_to_close_timeout`.
     google.protobuf.Timestamp expiration_time = 18;
     // Time when the activity transitioned to a closed state.
     google.protobuf.Timestamp close_time = 19;


### PR DESCRIPTION
**What changed?**
Fix standalone activity expiration_time doc to match actual behavior

**Why?**
The expiration time should take into account start delay
