### PR TITLE
💥 Update documention of current_retry_interval and next_attempt_schedule_time

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13707,7 +13707,7 @@
         },
         "currentRetryInterval": {
           "type": "string",
-          "description": "Time from the last attempt failure to the next activity retry.\nIf the activity is currently running, this represents the next retry interval in case the attempt fails.\nIf activity is currently backing off between attempt, this represents the current retry interval.\nIf there is no next retry allowed, this field will be null.\nThis interval is typically calculated from the specified retry policy, but may be modified if an activity fails\nwith a retryable application failure specifying a retry delay."
+          "description": "The retry interval for a currently pending retry: the amount of time between the last attempt\nfailure and when the next attempt will become available to worker poll requests. Set only\nduring retry backoff, i.e. when an activity is currently waiting for a retry, and the next\nactivity task has not yet become available to worker poll requests. Null at all other times,\nincluding when paused and during start delay. This is calculated from the active retry policy,\nbut can be overridden by an activity attempt that fails with a retryable application failure\nspecifying a next_retry_delay."
         },
         "lastAttemptCompleteTime": {
           "type": "string",
@@ -13717,7 +13717,7 @@
         "nextAttemptScheduleTime": {
           "type": "string",
           "format": "date-time",
-          "description": "The time when the next activity attempt will be scheduled.\nIf activity is currently scheduled or started, this field will be null."
+          "description": "The time at which the next activity attempt will become available to worker poll requests.\nSet only during start delay, and retry backoff. Null when paused."
         },
         "lastDeploymentVersion": {
           "$ref": "#/definitions/v1WorkerDeploymentVersion",
@@ -18037,7 +18037,7 @@
         },
         "currentRetryInterval": {
           "type": "string",
-          "description": "The time activity will wait until the next retry.\nIf activity is currently running it will be next retry interval if activity failed.\nIf activity is currently waiting it will be current retry interval.\nIf there will be no retry it will be null."
+          "description": "The retry interval for a currently pending retry: the amount of time between the last attempt\nfailure and when the next attempt will become available to worker poll requests. Set only\nduring retry backoff, i.e. when an activity is currently waiting for a retry, and the next\nactivity task has not yet become available to worker poll requests. Null at all other times\nincluding when paused. This is calculated from the active retry policy, but can be overridden by\nan activity attempt that fails with a retryable application failure specifying a next_retry_delay."
         },
         "lastAttemptCompleteTime": {
           "type": "string",
@@ -18047,7 +18047,7 @@
         "nextAttemptScheduleTime": {
           "type": "string",
           "format": "date-time",
-          "description": "Next time when activity will be scheduled.\nIf activity is currently scheduled or started it will be null."
+          "description": "The time at which the next activity attempt will become available to worker poll requests.\nSet only during retry backoff. Null when paused."
         },
         "paused": {
           "type": "boolean",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9878,12 +9878,13 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: |-
-            Time from the last attempt failure to the next activity retry.
-             If the activity is currently running, this represents the next retry interval in case the attempt fails.
-             If activity is currently backing off between attempt, this represents the current retry interval.
-             If there is no next retry allowed, this field will be null.
-             This interval is typically calculated from the specified retry policy, but may be modified if an activity fails
-             with a retryable application failure specifying a retry delay.
+            The retry interval for a currently pending retry: the amount of time between the last attempt
+             failure and when the next attempt will become available to worker poll requests. Set only
+             during retry backoff, i.e. when an activity is currently waiting for a retry, and the next
+             activity task has not yet become available to worker poll requests. Null at all other times,
+             including when paused and during start delay. This is calculated from the active retry policy,
+             but can be overridden by an activity attempt that fails with a retryable application failure
+             specifying a next_retry_delay.
         lastAttemptCompleteTime:
           type: string
           description: The time when the last activity attempt completed. If activity has not been completed yet, it will be null.
@@ -9891,8 +9892,8 @@ components:
         nextAttemptScheduleTime:
           type: string
           description: |-
-            The time when the next activity attempt will be scheduled.
-             If activity is currently scheduled or started, this field will be null.
+            The time at which the next activity attempt will become available to worker poll requests.
+             Set only during start delay, and retry backoff. Null when paused.
           format: date-time
         lastDeploymentVersion:
           allOf:
@@ -14416,10 +14417,12 @@ components:
           pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
           type: string
           description: |-
-            The time activity will wait until the next retry.
-             If activity is currently running it will be next retry interval if activity failed.
-             If activity is currently waiting it will be current retry interval.
-             If there will be no retry it will be null.
+            The retry interval for a currently pending retry: the amount of time between the last attempt
+             failure and when the next attempt will become available to worker poll requests. Set only
+             during retry backoff, i.e. when an activity is currently waiting for a retry, and the next
+             activity task has not yet become available to worker poll requests. Null at all other times
+             including when paused. This is calculated from the active retry policy, but can be overridden by
+             an activity attempt that fails with a retryable application failure specifying a next_retry_delay.
         lastAttemptCompleteTime:
           type: string
           description: The time when the last activity attempt was completed. If activity has not been completed yet then it will be null.
@@ -14427,8 +14430,8 @@ components:
         nextAttemptScheduleTime:
           type: string
           description: |-
-            Next time when activity will be scheduled.
-             If activity is currently scheduled or started it will be null.
+            The time at which the next activity attempt will become available to worker poll requests.
+             Set only during retry backoff. Null when paused.
           format: date-time
         paused:
           type: boolean

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -139,19 +139,20 @@ message ActivityExecutionInfo {
     temporal.api.failure.v1.Failure last_failure = 20;
     string last_worker_identity = 21;
 
-    // Time from the last attempt failure to the next activity retry.
-    // If the activity is currently running, this represents the next retry interval in case the attempt fails.
-    // If activity is currently backing off between attempt, this represents the current retry interval.
-    // If there is no next retry allowed, this field will be null.
-    // This interval is typically calculated from the specified retry policy, but may be modified if an activity fails
-    // with a retryable application failure specifying a retry delay.
+    // The retry interval for a currently pending retry: the amount of time between the last attempt
+    // failure and when the next attempt will become available to worker poll requests. Set only
+    // during retry backoff, i.e. when an activity is currently waiting for a retry, and the next
+    // activity task has not yet become available to worker poll requests. Null at all other times,
+    // including when paused and during start delay. This is calculated from the active retry policy,
+    // but can be overridden by an activity attempt that fails with a retryable application failure
+    // specifying a next_retry_delay.
     google.protobuf.Duration current_retry_interval = 22;
 
     // The time when the last activity attempt completed. If activity has not been completed yet, it will be null.
     google.protobuf.Timestamp last_attempt_complete_time = 23;
 
-    // The time when the next activity attempt will be scheduled.
-    // If activity is currently scheduled or started, this field will be null.
+    // The time at which the next activity attempt will become available to worker poll requests.
+    // Set only during start delay, and retry backoff. Null when paused.
     google.protobuf.Timestamp next_attempt_schedule_time = 24;
 
     // The Worker Deployment Version this activity was dispatched to most recently.

--- a/temporal/api/workflow/v1/message.proto
+++ b/temporal/api/workflow/v1/message.proto
@@ -311,17 +311,19 @@ message PendingActivityInfo {
     // This field should be cleaned up when versioning-2 API is removed. [cleanup-experimental-wv]
     temporal.api.common.v1.WorkerVersionStamp last_worker_version_stamp = 15 [deprecated = true];
 
-    // The time activity will wait until the next retry.
-    // If activity is currently running it will be next retry interval if activity failed.
-    // If activity is currently waiting it will be current retry interval.
-    // If there will be no retry it will be null.
+    // The retry interval for a currently pending retry: the amount of time between the last attempt
+    // failure and when the next attempt will become available to worker poll requests. Set only
+    // during retry backoff, i.e. when an activity is currently waiting for a retry, and the next
+    // activity task has not yet become available to worker poll requests. Null at all other times
+    // including when paused. This is calculated from the active retry policy, but can be overridden by
+    // an activity attempt that fails with a retryable application failure specifying a next_retry_delay.
     google.protobuf.Duration current_retry_interval = 16;
 
     // The time when the last activity attempt was completed. If activity has not been completed yet then it will be null.
     google.protobuf.Timestamp last_attempt_complete_time = 17;
 
-    // Next time when activity will be scheduled.
-    // If activity is currently scheduled or started it will be null.
+    // The time at which the next activity attempt will become available to worker poll requests.
+    // Set only during retry backoff. Null when paused.
     google.protobuf.Timestamp next_attempt_schedule_time = 18;
 
     // Indicates if activity is paused.


### PR DESCRIPTION
**What changed?**
- Update definition of `current_retry_interval` for WFA to reflect breaking behavior change made in https://github.com/temporalio/temporal/pull/11203
- Use equivalent wording for SAA

**Why?**
The current behavior of WFA was deemed to be a bug and changed in https://github.com/temporalio/temporal/pull/11203
