### PR TITLE
[SDK Ergonomics] NEXUS-519: Add link to QueryWorkflowResponse

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -18389,6 +18389,10 @@
         },
         "queryRejected": {
           "$ref": "#/definitions/v1QueryRejected"
+        },
+        "link": {
+          "$ref": "#/definitions/v1Link",
+          "description": "Holds the link to the Workflow execution that processed the Query."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -14905,6 +14905,10 @@ components:
           $ref: '#/components/schemas/Payloads'
         queryRejected:
           $ref: '#/components/schemas/QueryRejected'
+        link:
+          allOf:
+            - $ref: '#/components/schemas/Link'
+          description: Holds the link to the Workflow execution that processed the Query.
     RampByPercentage:
       type: object
       properties:

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -1187,6 +1187,8 @@ message QueryWorkflowRequest {
 message QueryWorkflowResponse {
     temporal.api.common.v1.Payloads query_result = 1;
     temporal.api.query.v1.QueryRejected query_rejected = 2;
+    // Holds the link to the Workflow execution that processed the Query. 
+    temporal.api.common.v1.Link link = 3;
 }
 
 message DescribeWorkflowExecutionRequest {


### PR DESCRIPTION

For Nexus Operations. Query is both read-only and sync- so
1. no callbacks
2. the link is only from caller to the handler- and is specifically a workflow link as there isnt a history event in handler for query

<!-- Describe what has changed in this PR -->
**What changed?**
Added link field to QueryWorkflowResponse

<!-- Tell your future self why have you made these changes -->
**Why?**
Required for QueryWorkflow-backed Nexus Operations

<!-- Are there any breaking changes on binary or code level? -->
**Breaking changes**
None

<!-- If this breaks the Server, please provide the Server PR to merge right after this PR was merged. -->
**Server PR**
https://github.com/temporalio/temporal/pull/11274 (Note: no server breakage) 