### PR TITLE
Add retry_state field to ActivityExecutionOutcome

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13591,6 +13591,10 @@
         "failure": {
           "$ref": "#/definitions/v1Failure",
           "description": "The failure if the activity completed unsuccessfully."
+        },
+        "retryState": {
+          "$ref": "#/definitions/v1RetryState",
+          "description": "The retry state associated with an unsuccessful activity execution.\nThis field is only meaningful when `failure` is set."
         }
       },
       "description": "The outcome of a completed activity execution: either a successful result or a failure."

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -9938,6 +9938,21 @@ components:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: The failure if the activity completed unsuccessfully.
+        retryState:
+          enum:
+            - RETRY_STATE_UNSPECIFIED
+            - RETRY_STATE_IN_PROGRESS
+            - RETRY_STATE_NON_RETRYABLE_FAILURE
+            - RETRY_STATE_TIMEOUT
+            - RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
+            - RETRY_STATE_RETRY_POLICY_NOT_SET
+            - RETRY_STATE_INTERNAL_SERVER_ERROR
+            - RETRY_STATE_CANCEL_REQUESTED
+          type: string
+          description: |-
+            The retry state associated with an unsuccessful activity execution.
+             This field is only meaningful when `failure` is set.
+          format: enum
       description: 'The outcome of a completed activity execution: either a successful result or a failure.'
     ActivityFailureInfo:
       type: object

--- a/temporal/api/activity/v1/message.proto
+++ b/temporal/api/activity/v1/message.proto
@@ -29,6 +29,10 @@ message ActivityExecutionOutcome {
         // The failure if the activity completed unsuccessfully.
         temporal.api.failure.v1.Failure failure = 2;
     }
+
+    // The retry state associated with an unsuccessful activity execution.
+    // This field is only meaningful when `failure` is set.
+    temporal.api.enums.v1.RetryState retry_state = 3;
 }
 
 message ActivityOptions {


### PR DESCRIPTION
**What changed?**
Added retry_state to ActivityExecutionOutcome 

**Why?**
Allow standalone activity callers to determine why retries stopped, such as a non-retryable failure, timeout, maximum attempts, or cancellation request. Required for workflow-activity parity.
