### PR TITLE
Add request IDs to activity update, unpause, and reset

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11783,7 +11783,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe cancellation requests within the targeted activity execution."
+          "description": "Used to de-dupe cancellation requests."
         },
         "reason": {
           "type": "string",
@@ -12773,7 +12773,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe termination requests within the targeted activity execution."
+          "description": "Used to de-dupe termination requests."
         },
         "reason": {
           "type": "string",

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11633,7 +11633,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run.\nFor standalone activities, specify a run ID to avoid retrying a different\nexecution when the activity ID is reused."
+          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run."
         },
         "identity": {
           "type": "string",
@@ -11649,7 +11649,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe pause requests within the targeted execution."
+          "description": "Used to de-dupe pause requests."
         }
       }
     },
@@ -11897,7 +11897,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run.\nFor standalone activities, specify a run ID to avoid retrying a different\nexecution when the activity ID is reused."
+          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run."
         },
         "identity": {
           "type": "string",
@@ -11921,7 +11921,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe reset requests within the targeted execution."
+          "description": "Used to de-dupe reset requests."
         }
       }
     },
@@ -12907,7 +12907,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Run ID of the workflow or standalone activity."
+          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run."
         },
         "identity": {
           "type": "string",
@@ -12935,7 +12935,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe unpause requests within the targeted execution."
+          "description": "Used to de-dupe unpause requests."
         }
       }
     },
@@ -12965,7 +12965,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run.\nFor standalone activities, specify a run ID to avoid retrying a different\nexecution when the activity ID is reused."
+          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run."
         },
         "identity": {
           "type": "string",
@@ -12989,7 +12989,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe update requests within the targeted execution."
+          "description": "Used to de-dupe update requests."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11633,7 +11633,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Run ID of the workflow or standalone activity."
+          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run.\nFor standalone activities, specify a run ID to avoid retrying a different\nexecution when the activity ID is reused."
         },
         "identity": {
           "type": "string",
@@ -11649,7 +11649,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe pause requests."
+          "description": "Used to de-dupe pause requests within the targeted execution."
         }
       }
     },
@@ -11775,7 +11775,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Activity run ID, targets the latest run if run_id is empty."
+          "description": "Activity run ID. If empty, targets the latest run.\nSpecify a run ID to avoid retrying a different execution when the activity ID is reused."
         },
         "identity": {
           "type": "string",
@@ -11783,7 +11783,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe cancellation requests."
+          "description": "Used to de-dupe cancellation requests within the targeted activity execution."
         },
         "reason": {
           "type": "string",
@@ -11897,7 +11897,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Run ID of the workflow or standalone activity."
+          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run.\nFor standalone activities, specify a run ID to avoid retrying a different\nexecution when the activity ID is reused."
         },
         "identity": {
           "type": "string",
@@ -11918,6 +11918,10 @@
         "resourceId": {
           "type": "string",
           "description": "Resource ID for routing. Contains \"workflow:{workflow_id}\" for workflow activities or \"activity:{activity_id}\" for standalone activities."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Used to de-dupe reset requests within the targeted execution."
         }
       }
     },
@@ -12761,7 +12765,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Activity run ID, targets the latest run if run_id is empty."
+          "description": "Activity run ID. If empty, targets the latest run.\nSpecify a run ID to avoid retrying a different execution when the activity ID is reused."
         },
         "identity": {
           "type": "string",
@@ -12769,7 +12773,7 @@
         },
         "requestId": {
           "type": "string",
-          "description": "Used to de-dupe termination requests."
+          "description": "Used to de-dupe termination requests within the targeted activity execution."
         },
         "reason": {
           "type": "string",
@@ -12928,6 +12932,10 @@
         "resourceId": {
           "type": "string",
           "description": "Resource ID for routing. Contains \"workflow:{workflow_id}\" for workflow activities or \"activity:{activity_id}\" for standalone activities."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Used to de-dupe unpause requests within the targeted execution."
         }
       }
     },
@@ -12957,7 +12965,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Run ID of the workflow or standalone activity."
+          "description": "Run ID of the workflow or standalone activity. If empty, targets the latest run.\nFor standalone activities, specify a run ID to avoid retrying a different\nexecution when the activity ID is reused."
         },
         "identity": {
           "type": "string",
@@ -12978,6 +12986,10 @@
         "resourceId": {
           "type": "string",
           "description": "Resource ID for routing. Contains \"workflow:{workflow_id}\" for workflow activities or \"activity:{activity_id}\" for standalone activities."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Used to de-dupe update requests within the targeted execution."
         }
       }
     },

--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -11775,7 +11775,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Activity run ID. If empty, targets the latest run.\nSpecify a run ID to avoid retrying a different execution when the activity ID is reused."
+          "description": "Activity run ID. If empty, targets the latest run."
         },
         "identity": {
           "type": "string",
@@ -12765,7 +12765,7 @@
       "properties": {
         "runId": {
           "type": "string",
-          "description": "Activity run ID. If empty, targets the latest run.\nSpecify a run ID to avoid retrying a different execution when the activity ID is reused."
+          "description": "Activity run ID. If empty, targets the latest run."
         },
         "identity": {
           "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15134,9 +15134,7 @@ components:
           type: string
         runId:
           type: string
-          description: |-
-            Activity run ID. If empty, targets the latest run.
-             Specify a run ID to avoid retrying a different execution when the activity ID is reused.
+          description: Activity run ID. If empty, targets the latest run.
         identity:
           type: string
           description: The identity of the worker/client.
@@ -17719,9 +17717,7 @@ components:
           type: string
         runId:
           type: string
-          description: |-
-            Activity run ID. If empty, targets the latest run.
-             Specify a run ID to avoid retrying a different execution when the activity ID is reused.
+          description: Activity run ID. If empty, targets the latest run.
         identity:
           type: string
           description: The identity of the worker/client.

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -14118,7 +14118,10 @@ components:
           description: The ID of the activity to target.
         runId:
           type: string
-          description: Run ID of the workflow or standalone activity.
+          description: |-
+            Run ID of the workflow or standalone activity. If empty, targets the latest run.
+             For standalone activities, specify a run ID to avoid retrying a different
+             execution when the activity ID is reused.
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -14130,7 +14133,7 @@ components:
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
         requestId:
           type: string
-          description: Used to de-dupe pause requests.
+          description: Used to de-dupe pause requests within the targeted execution.
     PauseActivityExecutionResponse:
       type: object
       properties: {}
@@ -15134,13 +15137,15 @@ components:
           type: string
         runId:
           type: string
-          description: Activity run ID, targets the latest run if run_id is empty.
+          description: |-
+            Activity run ID. If empty, targets the latest run.
+             Specify a run ID to avoid retrying a different execution when the activity ID is reused.
         identity:
           type: string
           description: The identity of the worker/client.
         requestId:
           type: string
-          description: Used to de-dupe cancellation requests.
+          description: Used to de-dupe cancellation requests within the targeted activity execution.
         reason:
           type: string
           description: |-
@@ -15354,7 +15359,10 @@ components:
           description: The ID of the activity to target.
         runId:
           type: string
-          description: Run ID of the workflow or standalone activity.
+          description: |-
+            Run ID of the workflow or standalone activity. If empty, targets the latest run.
+             For standalone activities, specify a run ID to avoid retrying a different
+             execution when the activity ID is reused.
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -15376,6 +15384,9 @@ components:
         resourceId:
           type: string
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
+        requestId:
+          type: string
+          description: Used to de-dupe reset requests within the targeted execution.
     ResetActivityExecutionResponse:
       type: object
       properties: {}
@@ -17714,13 +17725,15 @@ components:
           type: string
         runId:
           type: string
-          description: Activity run ID, targets the latest run if run_id is empty.
+          description: |-
+            Activity run ID. If empty, targets the latest run.
+             Specify a run ID to avoid retrying a different execution when the activity ID is reused.
         identity:
           type: string
           description: The identity of the worker/client.
         requestId:
           type: string
-          description: Used to de-dupe termination requests.
+          description: Used to de-dupe termination requests within the targeted activity execution.
         reason:
           type: string
           description: Reason for requesting the termination, recorded in in the activity's result failure outcome.
@@ -17997,6 +18010,9 @@ components:
         resourceId:
           type: string
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
+        requestId:
+          type: string
+          description: Used to de-dupe unpause requests within the targeted execution.
     UnpauseActivityExecutionResponse:
       type: object
       properties: {}
@@ -18078,7 +18094,10 @@ components:
           description: The ID of the activity to target.
         runId:
           type: string
-          description: Run ID of the workflow or standalone activity.
+          description: |-
+            Run ID of the workflow or standalone activity. If empty, targets the latest run.
+             For standalone activities, specify a run ID to avoid retrying a different
+             execution when the activity ID is reused.
         identity:
           type: string
           description: The identity of the client who initiated this request
@@ -18101,6 +18120,9 @@ components:
         resourceId:
           type: string
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
+        requestId:
+          type: string
+          description: Used to de-dupe update requests within the targeted execution.
     UpdateActivityExecutionOptionsResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -14118,10 +14118,7 @@ components:
           description: The ID of the activity to target.
         runId:
           type: string
-          description: |-
-            Run ID of the workflow or standalone activity. If empty, targets the latest run.
-             For standalone activities, specify a run ID to avoid retrying a different
-             execution when the activity ID is reused.
+          description: Run ID of the workflow or standalone activity. If empty, targets the latest run.
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -14133,7 +14130,7 @@ components:
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
         requestId:
           type: string
-          description: Used to de-dupe pause requests within the targeted execution.
+          description: Used to de-dupe pause requests.
     PauseActivityExecutionResponse:
       type: object
       properties: {}
@@ -15359,10 +15356,7 @@ components:
           description: The ID of the activity to target.
         runId:
           type: string
-          description: |-
-            Run ID of the workflow or standalone activity. If empty, targets the latest run.
-             For standalone activities, specify a run ID to avoid retrying a different
-             execution when the activity ID is reused.
+          description: Run ID of the workflow or standalone activity. If empty, targets the latest run.
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -15386,7 +15380,7 @@ components:
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
         requestId:
           type: string
-          description: Used to de-dupe reset requests within the targeted execution.
+          description: Used to de-dupe reset requests.
     ResetActivityExecutionResponse:
       type: object
       properties: {}
@@ -17990,7 +17984,7 @@ components:
           description: The ID of the activity to target.
         runId:
           type: string
-          description: Run ID of the workflow or standalone activity.
+          description: Run ID of the workflow or standalone activity. If empty, targets the latest run.
         identity:
           type: string
           description: The identity of the client who initiated this request.
@@ -18012,7 +18006,7 @@ components:
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
         requestId:
           type: string
-          description: Used to de-dupe unpause requests within the targeted execution.
+          description: Used to de-dupe unpause requests.
     UnpauseActivityExecutionResponse:
       type: object
       properties: {}
@@ -18094,10 +18088,7 @@ components:
           description: The ID of the activity to target.
         runId:
           type: string
-          description: |-
-            Run ID of the workflow or standalone activity. If empty, targets the latest run.
-             For standalone activities, specify a run ID to avoid retrying a different
-             execution when the activity ID is reused.
+          description: Run ID of the workflow or standalone activity. If empty, targets the latest run.
         identity:
           type: string
           description: The identity of the client who initiated this request
@@ -18122,7 +18113,7 @@ components:
           description: Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
         requestId:
           type: string
-          description: Used to de-dupe update requests within the targeted execution.
+          description: Used to de-dupe update requests.
     UpdateActivityExecutionOptionsResponse:
       type: object
       properties:

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15142,7 +15142,7 @@ components:
           description: The identity of the worker/client.
         requestId:
           type: string
-          description: Used to de-dupe cancellation requests within the targeted activity execution.
+          description: Used to de-dupe cancellation requests.
         reason:
           type: string
           description: |-
@@ -17727,7 +17727,7 @@ components:
           description: The identity of the worker/client.
         requestId:
           type: string
-          description: Used to de-dupe termination requests within the targeted activity execution.
+          description: Used to de-dupe termination requests.
         reason:
           type: string
           description: Reason for requesting the termination, recorded in in the activity's result failure outcome.

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2184,8 +2184,6 @@ message UpdateActivityExecutionOptionsRequest {
     // The ID of the activity to target.
     string activity_id = 3;
     // Run ID of the workflow or standalone activity. If empty, targets the latest run.
-    // For standalone activities, specify a run ID to avoid retrying a different
-    // execution when the activity ID is reused.
     string run_id = 4;
 
     // The identity of the client who initiated this request
@@ -2207,7 +2205,7 @@ message UpdateActivityExecutionOptionsRequest {
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 9;
 
-    // Used to de-dupe update requests within the targeted execution.
+    // Used to de-dupe update requests.
     string request_id = 10;
 }
 
@@ -2259,8 +2257,6 @@ message PauseActivityExecutionRequest {
     // The ID of the activity to target.
     string activity_id = 3;
     // Run ID of the workflow or standalone activity. If empty, targets the latest run.
-    // For standalone activities, specify a run ID to avoid retrying a different
-    // execution when the activity ID is reused.
     string run_id = 4;
 
     // The identity of the client who initiated this request.
@@ -2272,7 +2268,7 @@ message PauseActivityExecutionRequest {
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 7;
 
-    // Used to de-dupe pause requests within the targeted execution.
+    // Used to de-dupe pause requests.
     string request_id = 8;
 }
 
@@ -2322,7 +2318,7 @@ message UnpauseActivityExecutionRequest {
     string workflow_id = 2;
     // The ID of the activity to target.
     string activity_id = 3;
-    // Run ID of the workflow or standalone activity.
+    // Run ID of the workflow or standalone activity. If empty, targets the latest run.
     string run_id = 4;
 
     // The identity of the client who initiated this request.
@@ -2343,7 +2339,7 @@ message UnpauseActivityExecutionRequest {
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 10;
 
-    // Used to de-dupe unpause requests within the targeted execution.
+    // Used to de-dupe unpause requests.
     string request_id = 11;
 }
 
@@ -2402,8 +2398,6 @@ message ResetActivityExecutionRequest {
     // The ID of the activity to target.
     string activity_id = 3;
     // Run ID of the workflow or standalone activity. If empty, targets the latest run.
-    // For standalone activities, specify a run ID to avoid retrying a different
-    // execution when the activity ID is reused.
     string run_id = 4;
 
     // The identity of the client who initiated this request.
@@ -2424,7 +2418,7 @@ message ResetActivityExecutionRequest {
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 9;
 
-    // Used to de-dupe reset requests within the targeted execution.
+    // Used to de-dupe reset requests.
     string request_id = 10;
 }
 

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3563,7 +3563,6 @@ message RequestCancelActivityExecutionRequest {
     string namespace = 1;
     string activity_id = 2;
     // Activity run ID. If empty, targets the latest run.
-    // Specify a run ID to avoid retrying a different execution when the activity ID is reused.
     string run_id = 3;
     // The identity of the worker/client.
     string identity = 4;
@@ -3581,7 +3580,6 @@ message TerminateActivityExecutionRequest {
     string namespace = 1;
     string activity_id = 2;
     // Activity run ID. If empty, targets the latest run.
-    // Specify a run ID to avoid retrying a different execution when the activity ID is reused.
     string run_id = 3;
     // The identity of the worker/client.
     string identity = 4;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2183,7 +2183,9 @@ message UpdateActivityExecutionOptionsRequest {
     string workflow_id = 2;
     // The ID of the activity to target.
     string activity_id = 3;
-    // Run ID of the workflow or standalone activity.
+    // Run ID of the workflow or standalone activity. If empty, targets the latest run.
+    // For standalone activities, specify a run ID to avoid retrying a different
+    // execution when the activity ID is reused.
     string run_id = 4;
 
     // The identity of the client who initiated this request
@@ -2204,6 +2206,9 @@ message UpdateActivityExecutionOptionsRequest {
 
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 9;
+
+    // Used to de-dupe update requests within the targeted execution.
+    string request_id = 10;
 }
 
 // Deprecated. Use `UpdateActivityExecutionOptionsResponse`.
@@ -2253,7 +2258,9 @@ message PauseActivityExecutionRequest {
     string workflow_id = 2;
     // The ID of the activity to target.
     string activity_id = 3;
-    // Run ID of the workflow or standalone activity.
+    // Run ID of the workflow or standalone activity. If empty, targets the latest run.
+    // For standalone activities, specify a run ID to avoid retrying a different
+    // execution when the activity ID is reused.
     string run_id = 4;
 
     // The identity of the client who initiated this request.
@@ -2265,7 +2272,7 @@ message PauseActivityExecutionRequest {
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 7;
 
-    // Used to de-dupe pause requests.
+    // Used to de-dupe pause requests within the targeted execution.
     string request_id = 8;
 }
 
@@ -2335,6 +2342,9 @@ message UnpauseActivityExecutionRequest {
 
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 10;
+
+    // Used to de-dupe unpause requests within the targeted execution.
+    string request_id = 11;
 }
 
 // Deprecated. Use `UnpauseActivityExecutionResponse`.
@@ -2391,7 +2401,9 @@ message ResetActivityExecutionRequest {
     string workflow_id = 2;
     // The ID of the activity to target.
     string activity_id = 3;
-    // Run ID of the workflow or standalone activity.
+    // Run ID of the workflow or standalone activity. If empty, targets the latest run.
+    // For standalone activities, specify a run ID to avoid retrying a different
+    // execution when the activity ID is reused.
     string run_id = 4;
 
     // The identity of the client who initiated this request.
@@ -2411,6 +2423,9 @@ message ResetActivityExecutionRequest {
 
     // Resource ID for routing. Contains "workflow:{workflow_id}" for workflow activities or "activity:{activity_id}" for standalone activities.
     string resource_id = 9;
+
+    // Used to de-dupe reset requests within the targeted execution.
+    string request_id = 10;
 }
 
 // Deprecated. Use `ResetActivityExecutionRequest`.
@@ -3553,11 +3568,12 @@ message CountNexusOperationExecutionsResponse {
 message RequestCancelActivityExecutionRequest {
     string namespace = 1;
     string activity_id = 2;
-    // Activity run ID, targets the latest run if run_id is empty.
+    // Activity run ID. If empty, targets the latest run.
+    // Specify a run ID to avoid retrying a different execution when the activity ID is reused.
     string run_id = 3;
     // The identity of the worker/client.
     string identity = 4;
-    // Used to de-dupe cancellation requests.
+    // Used to de-dupe cancellation requests within the targeted activity execution.
     string request_id = 5;
     // Reason for requesting the cancellation, recorded and available via the PollActivityExecution API.
     // Not propagated to a worker if an activity attempt is currently running.
@@ -3570,11 +3586,12 @@ message RequestCancelActivityExecutionResponse {
 message TerminateActivityExecutionRequest {
     string namespace = 1;
     string activity_id = 2;
-    // Activity run ID, targets the latest run if run_id is empty.
+    // Activity run ID. If empty, targets the latest run.
+    // Specify a run ID to avoid retrying a different execution when the activity ID is reused.
     string run_id = 3;
     // The identity of the worker/client.
     string identity = 4;
-    // Used to de-dupe termination requests.
+    // Used to de-dupe termination requests within the targeted activity execution.
     string request_id = 5;
     // Reason for requesting the termination, recorded in in the activity's result failure outcome.
     string reason = 6;

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -3567,7 +3567,7 @@ message RequestCancelActivityExecutionRequest {
     string run_id = 3;
     // The identity of the worker/client.
     string identity = 4;
-    // Used to de-dupe cancellation requests within the targeted activity execution.
+    // Used to de-dupe cancellation requests.
     string request_id = 5;
     // Reason for requesting the cancellation, recorded and available via the PollActivityExecution API.
     // Not propagated to a worker if an activity attempt is currently running.
@@ -3585,7 +3585,7 @@ message TerminateActivityExecutionRequest {
     string run_id = 3;
     // The identity of the worker/client.
     string identity = 4;
-    // Used to de-dupe termination requests within the targeted activity execution.
+    // Used to de-dupe termination requests.
     string request_id = 5;
     // Reason for requesting the termination, recorded in in the activity's result failure outcome.
     string reason = 6;


### PR DESCRIPTION
**What changed?**
Added request_id fields to update, unpause, and reset activity execution requests. Also clarified the run_id and request_id documentation for related activity APIs, including how omitted run IDs affect targeting and how request IDs are scoped to targeted executions.

**Why?**
To support idempotent retries within the targeted activity execution, prevent duplicate mutations after ambiguous timeouts or failures, and make run-targeting and request-deduplication behavior clearer to API users.

