### PR TITLE
Add reset_heartbeats field to ResetActivityExecutionRequest

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -12020,6 +12020,10 @@
         "requestId": {
           "type": "string",
           "description": "Used to de-dupe reset requests."
+        },
+        "resetHeartbeat": {
+          "type": "boolean",
+          "description": "Reset persisted heartbeat details.\nReset always resets the attempt counter. Passing this flag causes reset to additionally\ndiscard any persisted heartbeat details."
         }
       }
     },

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -15529,6 +15529,12 @@ components:
         requestId:
           type: string
           description: Used to de-dupe reset requests.
+        resetHeartbeat:
+          type: boolean
+          description: |-
+            Reset persisted heartbeat details.
+             Reset always resets the attempt counter. Passing this flag causes reset to additionally
+             discard any persisted heartbeat details.
     ResetActivityExecutionResponse:
       type: object
       properties: {}

--- a/temporal/api/workflowservice/v1/request_response.proto
+++ b/temporal/api/workflowservice/v1/request_response.proto
@@ -2420,6 +2420,12 @@ message ResetActivityExecutionRequest {
 
     // Used to de-dupe reset requests.
     string request_id = 10;
+
+    // Reset persisted heartbeat details.
+    // Reset always resets the attempt counter. Passing this flag causes reset to additionally
+    // discard any persisted heartbeat details.
+    bool reset_heartbeat = 11;
+
 }
 
 // Deprecated. Use `ResetActivityExecutionRequest`.


### PR DESCRIPTION
This PR reverts "remove reset_heartbeats field in ResetActivityExecutionRequest (#820 e74dc689a5630d7381e3fd143fa97fe6186d480e)"

**What changed?**
- Add reset_heartbeats field to ResetActivityExecutionRequest


**Why?**
- Parity with WFA
- This product behavior makes sense: a user with a long-running activity using exponential backoff on attempt 10 may wish to reset the attempt counter in order that the next retry backoff is short, and yet preserve their checkpointed progress.

**Breaking changes**
No
