### PR TITLE
Remove 'Outcome' types, moving fields to parent protos

### DIFF
--- a/openapi/openapiv2.json
+++ b/openapi/openapiv2.json
@@ -13511,9 +13511,14 @@
           "type": "string",
           "description": "If the state is BLOCKED, blocked reason provides additional information."
         },
-        "outcome": {
-          "$ref": "#/definitions/v1CallbackOutcome",
-          "description": "Result of the callback's execution, only set when the callback reaches a terminal state."
+        "success": {
+          "type": "object",
+          "properties": {},
+          "title": "The callback completed successfully. (Which may include delivering a \"failed\" result successfully.)"
+        },
+        "failure": {
+          "$ref": "#/definitions/v1Failure",
+          "description": "The failure if the callback was not able to complete successfully. e.g. timed out, received an\nunretriable error, etc."
         }
       },
       "description": "Common callback information. Specific CallbackInfo messages should embed this and may include additional fields."
@@ -14750,20 +14755,6 @@
         }
       },
       "description": "Callback to attach to various events in the system, e.g. workflow run completion."
-    },
-    "v1CallbackOutcome": {
-      "type": "object",
-      "properties": {
-        "success": {
-          "type": "object",
-          "properties": {},
-          "title": "The callback completed successfully. (Which may include delivering a \"failed\" result successfully.)"
-        },
-        "failure": {
-          "$ref": "#/definitions/v1Failure",
-          "description": "The failure if the callback was not able to complete successfully. e.g. timed out, received an\nunretriable error, etc."
-        }
-      }
     },
     "v1CallbackState": {
       "type": "string",

--- a/openapi/openapiv3.yaml
+++ b/openapi/openapiv3.yaml
@@ -10905,20 +10905,13 @@ components:
         blockedReason:
           type: string
           description: If the state is BLOCKED, blocked reason provides additional information.
-        outcome:
-          allOf:
-            - $ref: '#/components/schemas/CallbackOutcome'
-          description: Result of the callback's execution, only set when the callback reaches a terminal state.
-      description: Common callback information. Specific CallbackInfo messages should embed this and may include additional fields.
-    CallbackOutcome:
-      type: object
-      properties:
         failure:
           allOf:
             - $ref: '#/components/schemas/Failure'
           description: |-
             The failure if the callback was not able to complete successfully. e.g. timed out, received an
              unretriable error, etc.
+      description: Common callback information. Specific CallbackInfo messages should embed this and may include additional fields.
     Callback_Internal:
       type: object
       properties:

--- a/temporal/api/callback/v1/message.proto
+++ b/temporal/api/callback/v1/message.proto
@@ -37,15 +37,11 @@ message CallbackInfo {
     string blocked_reason = 8;
 
     // Result of the callback's execution, only set when the callback reaches a terminal state.
-    CallbackOutcome outcome = 9;
-}
-
-message CallbackOutcome {
-    oneof value {
+    oneof result {
         // The callback completed successfully. (Which may include delivering a "failed" result successfully.)
-        google.protobuf.Empty success = 1;
+        google.protobuf.Empty success = 9;
         // The failure if the callback was not able to complete successfully. e.g. timed out, received an
         // unretriable error, etc.
-        temporal.api.failure.v1.Failure failure = 2;
+        temporal.api.failure.v1.Failure failure = 10;
     }
 }

--- a/temporal/api/notificationservice/v1/request_response.proto
+++ b/temporal/api/notificationservice/v1/request_response.proto
@@ -21,19 +21,16 @@ import "temporal/api/failure/v1/message.proto";
 // sent to the worker callback. (In addition to this OnCompleteRequest.)
 message OnCompleteRequest {
 
-    // The outcome of the source operation.
-    message Outcome {
-        oneof result {
-            // The operation was successful, and resulted in the given payload(s).
-            temporal.api.common.v1.Payloads success = 1;
-            // The operation failed. Includes timeout, cancellation, and application errors.
-            temporal.api.failure.v1.Failure failure = 2;
-        }
+    // The result of the source operation.
+    oneof result {
+        // The operation was successful, and resulted in the given payload.
+        temporal.api.common.v1.Payload success = 1;
+        // The operation failed. Includes timeout, cancellation, and application errors.
+        temporal.api.failure.v1.Failure failure = 2;
     }
-    Outcome outcome = 1;
 
     // User-supplied data which was added to the source invocation. (As applicable.)
-    temporal.api.common.v1.Payload source_context = 2;
+    temporal.api.common.v1.Payload source_context = 3;
 }
 
 // OnCompleteResponse is the return type of the OnComplete operation.


### PR DESCRIPTION
**What changed?**
**Why?**

There are two changes in this PR, **both breaking changes**. (But since the feature is under development, this won't impact users in any way.)

(1) Remove the `callbackpb.CallbackOutcome` proto, and instead move the `success`/`failure` fields directly into `callbackpb.CallbackInfo`. Do the same for `OnCompleteRequest`, removing the `OnCompleteRequest.Outcome` message.

It's extremely unlikely we would ever add a new variant for the callback's result, and having the extra layer of indirection made the SDK and server-side code cumbersome.

(2) Have `OnCompleteRequest.result` variant `success` be a `commonpb.Payload` instead of a `commonpb.Payloads`.

The Temporal API makes it look as if a Workflow can return multiple values. (i.e. a `commonpb.Payloads`.) But in reality, the SDK only ever deals with a single value (`commonpb.Payload`).

And the extra layer of indirection via `commonpb.Payloads` also made the SDK and server-side code more cumbersome.

**Breaking changes**

Yes. But this is still a WIP feature branch. The only person being broken is, alas, @chrsmith .
